### PR TITLE
feat(ci): 配置自动发布到 npm 的工作流

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9.15.4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Packages
+        run: pnpm build
+
+      - name: Create Release Pull Request or Publish to npm
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          publish: pnpm release
+          commit: 'chore: release packages'
+          title: 'chore: release packages'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "demo:agent": "tsx demo/stello-agent-basic/demo.ts",
     "demo:chat": "pnpm --dir demo/stello-agent-chat build && tsx demo/stello-agent-chat/chat-devtools.ts",
     "lint": "eslint .",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "release": "pnpm build && changeset publish"
   },
   "devDependencies": {
     "@changesets/cli": "^2.30.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,6 +42,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsup",
     "test": "vitest run",

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -28,6 +28,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build:server": "tsup",
     "build:web": "cd web && pnpm exec vite build",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -39,6 +39,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsup",
     "test": "vitest run",

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -42,6 +42,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsup",
     "test": "vitest run",

--- a/packages/visualizer/package.json
+++ b/packages/visualizer/package.json
@@ -42,6 +42,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsup",
     "test": "vitest run",


### PR DESCRIPTION
## 📦 配置自动发布工作流

这个 PR 配置了自动发布到 npm 的完整流程。

### 🎯 改动内容

1. **新增 GitHub Actions workflow**
   - `.github/workflows/release.yml`
   - 在 PR 合并到 main 时自动运行
   - 使用 `changesets/action` 管理版本和发布

2. **添加发布脚本**
   - 根目录 `package.json` 添加 `release` 脚本
   - 执行构建并发布到 npm

3. **配置包发布权限**
   - 所有包添加 `publishConfig.access = "public"`
   - 确保 scoped 包可以公开发布

### 📋 影响的包

- `@stello-ai/core`
- `@stello-ai/session`
- `@stello-ai/server`
- `@stello-ai/devtools`
- `@stello-ai/visualizer`

### 🔄 工作流程

```
1. 开发者提交 PR（包含 changeset）
   ↓
2. 合并到 main
   ↓
3. GitHub Actions 自动创建 "Version Packages" PR
   ↓
4. Maintainer 合并 Version PR
   ↓
5. 自动发布到 npm + 打 git tag
```

### ✅ 前置配置

以下配置已完成：
- [x] NPM_TOKEN 已添加到 GitHub Secrets
- [x] Workflow permissions 设置为 "Read and write"
- [x] 允许 GitHub Actions 创建 PR

### 🧪 测试计划

合并此 PR 后：
1. 测试 GitHub Actions 是否成功运行
2. 验证是否会创建 Version PR
3. **不会立即发版**（需要手动合并 Version PR）

### 📚 相关文档

- [Changesets 工作原理](https://github.com/changesets/changesets)
- [团队使用指南](docs/RELEASE_WORKFLOW.md)（待添加）

---

🤖 Generated with Claude Code