### PR TITLE
feat(session): 实现 context compress — token 预算模式的上下文压缩

### DIFF
--- a/packages/server/src/storage/pg-session-storage.ts
+++ b/packages/server/src/storage/pg-session-storage.ts
@@ -122,6 +122,16 @@ export class PgSessionStorage implements SessionStorage {
     return rows.map(rowToMessage)
   }
 
+  /** 裁剪旧 L3，保留最近 keepRecent 条 */
+  async trimRecords(sessionId: string, keepRecent: number): Promise<void> {
+    await this.client.query(
+      `DELETE FROM records WHERE session_id = $1 AND id NOT IN (
+        SELECT id FROM records WHERE session_id = $1 ORDER BY id DESC LIMIT $2
+      )`,
+      [sessionId, keepRecent],
+    )
+  }
+
   /** 读取 system prompt */
   async getSystemPrompt(sessionId: string): Promise<string | null> {
     return this.getSlot(sessionId, 'system_prompt')

--- a/packages/session/src/__tests__/context-compress.test.ts
+++ b/packages/session/src/__tests__/context-compress.test.ts
@@ -1,0 +1,375 @@
+import { describe, it, expect, vi } from 'vitest'
+import { makeSession, createMockLLM } from './helpers.js'
+import { createMainSession } from '../create-main-session.js'
+import { InMemoryStorageAdapter } from '../mocks/in-memory-storage.js'
+import { SessionArchivedError } from '../types/session-api.js'
+import type { LLMResult, Message } from '../types/llm.js'
+import type { CountTokensFn, ContextWindowOptions } from '../types/functions.js'
+
+/** 简单的 token 计数：每条消息的内容长度之和 */
+const charCounter: CountTokensFn = (msgs) =>
+  msgs.reduce((sum, m) => sum + m.content.length, 0)
+
+const simpleResponse: LLMResult = {
+  content: 'OK',
+  usage: { promptTokens: 10, completionTokens: 2 },
+}
+
+describe('trimRecords()', () => {
+  it('保留最近 N 条，删除更早的记录', async () => {
+    const { session, storage } = await makeSession()
+    const id = session.meta.id
+    await storage.appendRecord(id, { role: 'user', content: 'msg1' })
+    await storage.appendRecord(id, { role: 'assistant', content: 'reply1' })
+    await storage.appendRecord(id, { role: 'user', content: 'msg2' })
+    await storage.appendRecord(id, { role: 'assistant', content: 'reply2' })
+
+    await session.trimRecords(2)
+
+    const messages = await session.messages()
+    expect(messages).toHaveLength(2)
+    expect(messages[0]!.content).toBe('msg2')
+    expect(messages[1]!.content).toBe('reply2')
+  })
+
+  it('keepRecent 大于总数时无操作', async () => {
+    const { session, storage } = await makeSession()
+    await storage.appendRecord(session.meta.id, { role: 'user', content: 'msg1' })
+
+    await session.trimRecords(10)
+
+    const messages = await session.messages()
+    expect(messages).toHaveLength(1)
+  })
+
+  it('keepRecent = 0 时清空所有记录', async () => {
+    const { session, storage } = await makeSession()
+    await storage.appendRecord(session.meta.id, { role: 'user', content: 'msg1' })
+    await storage.appendRecord(session.meta.id, { role: 'assistant', content: 'reply1' })
+
+    await session.trimRecords(0)
+
+    const messages = await session.messages()
+    expect(messages).toHaveLength(0)
+  })
+
+  it('空 session trimRecords 不报错', async () => {
+    const { session } = await makeSession()
+    await expect(session.trimRecords(5)).resolves.not.toThrow()
+  })
+
+  it('archived session 调用 trimRecords 抛错', async () => {
+    const { session } = await makeSession()
+    await session.archive()
+    await expect(session.trimRecords(5)).rejects.toThrow(SessionArchivedError)
+  })
+})
+
+describe('Session 上下文压缩', () => {
+  it('无 contextWindow 时全量回放所有 L3', async () => {
+    const capturedMessages: Message[][] = []
+    const llm = createMockLLM([simpleResponse, simpleResponse])
+    const origComplete = llm.complete.bind(llm)
+    llm.complete = async (msgs) => {
+      capturedMessages.push([...msgs])
+      return origComplete(msgs)
+    }
+
+    const { session } = await makeSession({ llm })
+    await session.send('msg1')
+    await session.send('msg2')
+
+    // 第二次 send：2 条 L3 历史(user+assistant) + 当前用户消息 = 3
+    const secondCall = capturedMessages[1]!
+    expect(secondCall).toHaveLength(3)
+    expect(secondCall[0]!.content).toBe('msg1')
+    expect(secondCall[1]!.content).toBe('OK')
+    expect(secondCall[2]!.content).toBe('msg2')
+  })
+
+  it('配置 contextWindow 且有 L2 时注入 L2 并按预算裁剪 L3', async () => {
+    const capturedMessages: Message[][] = []
+    const llm = createMockLLM([simpleResponse])
+    const origComplete = llm.complete.bind(llm)
+    llm.complete = async (msgs) => {
+      capturedMessages.push([...msgs])
+      return origComplete(msgs)
+    }
+
+    const contextWindow: ContextWindowOptions = {
+      maxContextTokens: 100,
+      countTokens: charCounter,
+    }
+
+    const { session, storage } = await makeSession({ llm, contextWindow })
+    const id = session.meta.id
+
+    // 存入 L2
+    await storage.putMemory(id, 'summary of past conversation')
+    // 存入一些 L3 历史
+    await storage.appendRecord(id, { role: 'user', content: 'old-message-that-is-very-long-and-should-be-trimmed-away' })
+    await storage.appendRecord(id, { role: 'assistant', content: 'old-reply-also-long-enough-to-exceed-budget' })
+    await storage.appendRecord(id, { role: 'user', content: 'recent' })
+    await storage.appendRecord(id, { role: 'assistant', content: 'ok' })
+
+    await session.send('new question')
+
+    const call = capturedMessages[0]!
+    // 应该包含: L2 (system) + 能放入预算的最近 L3 + 当前用户消息
+    // L2 作为 system 消息应该在上下文中
+    const systemMessages = call.filter(m => m.role === 'system')
+    expect(systemMessages.some(m => m.content === 'summary of past conversation')).toBe(true)
+
+    // 最后一条应该是当前用户消息
+    expect(call[call.length - 1]!.content).toBe('new question')
+
+    // 由于预算有限，不应包含所有 4 条 L3
+    const totalL3 = call.filter(m => m.role !== 'system')
+    // 至少包含当前用户消息
+    expect(totalL3.length).toBeGreaterThanOrEqual(1)
+    // 不应包含全部历史（否则超出预算）
+    expect(totalL3.length).toBeLessThanOrEqual(4) // at most recent L3 + current
+  })
+
+  it('配置 contextWindow 但无 L2 时仍按预算裁剪 L3', async () => {
+    const capturedMessages: Message[][] = []
+    const llm = createMockLLM([simpleResponse])
+    const origComplete = llm.complete.bind(llm)
+    llm.complete = async (msgs) => {
+      capturedMessages.push([...msgs])
+      return origComplete(msgs)
+    }
+
+    const contextWindow: ContextWindowOptions = {
+      maxContextTokens: 30, // very tight
+      countTokens: charCounter,
+    }
+
+    const { session, storage } = await makeSession({ llm, contextWindow })
+    const id = session.meta.id
+
+    // 不设置 L2
+    await storage.appendRecord(id, { role: 'user', content: 'aaaaaaaaaa' }) // 10 chars
+    await storage.appendRecord(id, { role: 'assistant', content: 'bbbbbbbbbb' }) // 10 chars
+    await storage.appendRecord(id, { role: 'user', content: 'cccc' }) // 4 chars
+    await storage.appendRecord(id, { role: 'assistant', content: 'dddd' }) // 4 chars
+
+    await session.send('hi') // 2 chars for user msg
+
+    const call = capturedMessages[0]!
+    // 预算 30，用户消息 2，剩余 28 给 L3
+    // 应该只包含能装入预算的最近几条
+    expect(call[call.length - 1]!.content).toBe('hi')
+    // 不应包含 system 消息（无 L2、无 system prompt、无 insight）
+    expect(call.filter(m => m.role === 'system')).toHaveLength(0)
+  })
+
+  it('预算极小时至少包含用户消息', async () => {
+    const capturedMessages: Message[][] = []
+    const llm = createMockLLM([simpleResponse])
+    const origComplete = llm.complete.bind(llm)
+    llm.complete = async (msgs) => {
+      capturedMessages.push([...msgs])
+      return origComplete(msgs)
+    }
+
+    const contextWindow: ContextWindowOptions = {
+      maxContextTokens: 5, // barely enough for user msg
+      countTokens: charCounter,
+    }
+
+    const { session, storage } = await makeSession({ llm, contextWindow })
+    await storage.appendRecord(session.meta.id, { role: 'user', content: 'old message' })
+
+    await session.send('hi')
+
+    const call = capturedMessages[0]!
+    // 应该至少有用户消息
+    expect(call.length).toBeGreaterThanOrEqual(1)
+    expect(call[call.length - 1]!.content).toBe('hi')
+  })
+
+  it('stream() 同样支持 contextWindow 压缩', async () => {
+    const capturedMessages: Message[][] = []
+    const llm = {
+      async complete(msgs: Message[]) {
+        capturedMessages.push([...msgs])
+        return { content: 'streamed' }
+      },
+      async *stream(msgs: Message[]) {
+        capturedMessages.push([...msgs])
+        yield { delta: 'streamed' }
+      },
+    }
+
+    const contextWindow: ContextWindowOptions = {
+      maxContextTokens: 50,
+      countTokens: charCounter,
+    }
+
+    const { session, storage } = await makeSession({ llm, contextWindow })
+    const id = session.meta.id
+    await storage.putMemory(id, 'L2 summary')
+    await storage.appendRecord(id, { role: 'user', content: 'old msg very very long to exceed budget' })
+    await storage.appendRecord(id, { role: 'assistant', content: 'old reply also very long to exceed budget' })
+
+    const stream = session.stream('new')
+    for await (const _chunk of stream) { /* drain */ }
+    await stream.result
+
+    const call = capturedMessages[0]!
+    // L2 应该在上下文中
+    expect(call.some(m => m.role === 'system' && m.content === 'L2 summary')).toBe(true)
+    expect(call[call.length - 1]!.content).toBe('new')
+  })
+})
+
+describe('MainSession 上下文压缩', () => {
+  it('MainSession 配置 contextWindow 后按预算裁剪 L3', async () => {
+    const capturedMessages: Message[][] = []
+    const storage = new InMemoryStorageAdapter()
+    const llm = createMockLLM([simpleResponse])
+    const origComplete = llm.complete.bind(llm)
+    llm.complete = async (msgs) => {
+      capturedMessages.push([...msgs])
+      return origComplete(msgs)
+    }
+
+    const contextWindow: ContextWindowOptions = {
+      maxContextTokens: 80,
+      countTokens: charCounter,
+    }
+
+    const mainSession = await createMainSession({
+      storage,
+      llm,
+      contextWindow,
+      systemPrompt: 'you are main',
+    })
+
+    const id = mainSession.meta.id
+    // 设置 synthesis
+    await storage.putMemory(id, 'global synthesis')
+    // 添加长 L3 历史
+    await storage.appendRecord(id, { role: 'user', content: 'very long old message that should be trimmed' })
+    await storage.appendRecord(id, { role: 'assistant', content: 'very long old reply that should be trimmed' })
+    await storage.appendRecord(id, { role: 'user', content: 'recent' })
+    await storage.appendRecord(id, { role: 'assistant', content: 'ok' })
+
+    await mainSession.send('hello')
+
+    const call = capturedMessages[0]!
+    // system prompt 和 synthesis 都应在上下文中
+    expect(call[0]!.content).toBe('you are main')
+    expect(call[1]!.content).toBe('global synthesis')
+    // 最后是当前用户消息
+    expect(call[call.length - 1]!.content).toBe('hello')
+  })
+
+  it('MainSession trimRecords 正常工作', async () => {
+    const storage = new InMemoryStorageAdapter()
+    const mainSession = await createMainSession({ storage })
+
+    const id = mainSession.meta.id
+    await storage.appendRecord(id, { role: 'user', content: 'a' })
+    await storage.appendRecord(id, { role: 'assistant', content: 'b' })
+    await storage.appendRecord(id, { role: 'user', content: 'c' })
+    await storage.appendRecord(id, { role: 'assistant', content: 'd' })
+
+    await mainSession.trimRecords(2)
+
+    const msgs = await mainSession.messages()
+    expect(msgs).toHaveLength(2)
+    expect(msgs[0]!.content).toBe('c')
+    expect(msgs[1]!.content).toBe('d')
+  })
+})
+
+describe('trimRecords 边界条件', () => {
+  it('负数 keepRecent 抛错', async () => {
+    const { session } = await makeSession()
+    await expect(session.trimRecords(-1)).rejects.toThrow('keepRecent must be a non-negative integer')
+  })
+})
+
+describe('上下文预算边界', () => {
+  it('固定部分已超预算时仍发送固定消息（不含 L3）', async () => {
+    const capturedMessages: Message[][] = []
+    const llm = createMockLLM([simpleResponse])
+    const origComplete = llm.complete.bind(llm)
+    llm.complete = async (msgs) => {
+      capturedMessages.push([...msgs])
+      return origComplete(msgs)
+    }
+
+    const contextWindow: ContextWindowOptions = {
+      maxContextTokens: 10, // system prompt + user msg 就超了
+      countTokens: charCounter,
+    }
+
+    const { session, storage } = await makeSession({
+      llm,
+      contextWindow,
+      systemPrompt: 'a very long system prompt that exceeds budget',
+    })
+    await storage.appendRecord(session.meta.id, { role: 'user', content: 'old msg' })
+
+    await session.send('hi')
+
+    const call = capturedMessages[0]!
+    // 固定消息（system prompt + user msg）应该在，L3 不应在
+    expect(call[0]!.content).toBe('a very long system prompt that exceeds budget')
+    expect(call[call.length - 1]!.content).toBe('hi')
+    // 不应包含旧的 L3
+    expect(call.find(m => m.content === 'old msg')).toBeUndefined()
+  })
+})
+
+describe('consolidate + trimRecords 工作流', () => {
+  it('consolidate 生成 L2 后 trimRecords 裁剪旧 L3，后续 send 使用 L2 + 最近 L3', async () => {
+    const capturedMessages: Message[][] = []
+    const llm = createMockLLM([simpleResponse, simpleResponse, simpleResponse])
+    const origComplete = llm.complete.bind(llm)
+    llm.complete = async (msgs) => {
+      capturedMessages.push([...msgs])
+      return origComplete(msgs)
+    }
+
+    const contextWindow: ContextWindowOptions = {
+      maxContextTokens: 200,
+      countTokens: charCounter,
+    }
+
+    const { session, storage } = await makeSession({ llm, contextWindow })
+    const id = session.meta.id
+
+    // 模拟几轮对话
+    await session.send('msg1')
+    await session.send('msg2')
+
+    // consolidate 生成 L2
+    await session.consolidate(async (_mem, msgs) => {
+      return `Summary: ${msgs.length} messages consolidated`
+    })
+
+    // 验证 L2 已生成
+    const l2 = await session.memory()
+    expect(l2).toBe('Summary: 4 messages consolidated')
+
+    // 裁剪旧 L3，只保留最近 2 条
+    await session.trimRecords(2)
+    const remaining = await session.messages()
+    expect(remaining).toHaveLength(2)
+
+    // 再次 send — 上下文应包含 L2 + 最近 L3 + 当前消息
+    await session.send('msg3')
+
+    const lastCall = capturedMessages[2]!
+    // L2 作为 system 消息
+    expect(lastCall.some(m =>
+      m.role === 'system' && m.content.includes('Summary:')
+    )).toBe(true)
+    // 最后是当前用户消息
+    expect(lastCall[lastCall.length - 1]!.content).toBe('msg3')
+  })
+})

--- a/packages/session/src/context-utils.ts
+++ b/packages/session/src/context-utils.ts
@@ -1,0 +1,143 @@
+import type { Message } from './types/llm.js'
+import type { ContextWindowOptions } from './types/functions.js'
+import type { SessionStorage } from './types/storage.js'
+
+/** 按 token 预算从最近的 L3 往前填充，返回能装入预算的消息 */
+export function selectHistoryByBudget(
+  history: Message[],
+  remainingBudget: number,
+  countTokens: (messages: Message[]) => number,
+): Message[] {
+  // 逐条累加 token 消耗，从最近往前
+  let usedTokens = 0
+  let startIndex = history.length
+  for (let i = history.length - 1; i >= 0; i--) {
+    const msgTokens = countTokens([history[i]!])
+    if (usedTokens + msgTokens > remainingBudget) break
+    usedTokens += msgTokens
+    startIndex = i
+  }
+  return history.slice(startIndex)
+}
+
+/** assembleContext 的返回结果 */
+export interface AssembleResult {
+  /** 组装好的消息数组 */
+  messages: Message[]
+  /** 是否消费了 insight（需要后续清除） */
+  insightConsumed: boolean
+  /** 用户消息的时间戳 */
+  userTimestamp: string
+}
+
+/** 组装 Session 上下文：system prompt → insight → [L2] → L3 历史 → user msg */
+export async function assembleSessionContext(
+  sessionId: string,
+  storage: SessionStorage,
+  userContent: string,
+  contextWindow?: ContextWindowOptions,
+): Promise<AssembleResult> {
+  const fixedMessages: Message[] = []
+  let insightConsumed = false
+
+  // 1. system prompt
+  const sysPrompt = await storage.getSystemPrompt(sessionId)
+  if (sysPrompt) {
+    fixedMessages.push({ role: 'system', content: sysPrompt })
+  }
+
+  // 2. insight（读取后标记消费）
+  const insightContent = await storage.getInsight(sessionId)
+  if (insightContent) {
+    fixedMessages.push({ role: 'system', content: insightContent })
+    insightConsumed = true
+  }
+
+  // 3. L2 memory（仅在 contextWindow 模式下注入）
+  if (contextWindow) {
+    const memory = await storage.getMemory(sessionId)
+    if (memory) {
+      fixedMessages.push({ role: 'system', content: memory })
+    }
+  }
+
+  const userTimestamp = new Date().toISOString()
+  const userMessage: Message = {
+    role: 'user',
+    content: userContent,
+    timestamp: userTimestamp,
+  }
+
+  const history = await storage.listRecords(sessionId)
+
+  if (contextWindow) {
+    // token 预算模式：固定部分 + 用户消息先占预算，剩余给 L3
+    const fixedTokens = contextWindow.countTokens([...fixedMessages, userMessage])
+    const remainingBudget = contextWindow.maxContextTokens - fixedTokens
+    const selectedHistory = remainingBudget > 0
+      ? selectHistoryByBudget(history, remainingBudget, contextWindow.countTokens)
+      : []
+    return {
+      messages: [...fixedMessages, ...selectedHistory, userMessage],
+      insightConsumed,
+      userTimestamp,
+    }
+  }
+
+  // 向后兼容：全量回放
+  return {
+    messages: [...fixedMessages, ...history, userMessage],
+    insightConsumed,
+    userTimestamp,
+  }
+}
+
+/** 组装 MainSession 上下文：system prompt → synthesis → L3 历史 → user msg */
+export async function assembleMainSessionContext(
+  sessionId: string,
+  storage: SessionStorage,
+  userContent: string,
+  contextWindow?: ContextWindowOptions,
+): Promise<{ messages: Message[]; userTimestamp: string }> {
+  const fixedMessages: Message[] = []
+
+  // 1. system prompt
+  const sysPrompt = await storage.getSystemPrompt(sessionId)
+  if (sysPrompt) {
+    fixedMessages.push({ role: 'system', content: sysPrompt })
+  }
+
+  // 2. synthesis（MainSession 始终注入，不受 contextWindow 影响）
+  const synthContent = await storage.getMemory(sessionId)
+  if (synthContent) {
+    fixedMessages.push({ role: 'system', content: synthContent })
+  }
+
+  const userTimestamp = new Date().toISOString()
+  const userMessage: Message = {
+    role: 'user',
+    content: userContent,
+    timestamp: userTimestamp,
+  }
+
+  const history = await storage.listRecords(sessionId)
+
+  if (contextWindow) {
+    // token 预算模式
+    const fixedTokens = contextWindow.countTokens([...fixedMessages, userMessage])
+    const remainingBudget = contextWindow.maxContextTokens - fixedTokens
+    const selectedHistory = remainingBudget > 0
+      ? selectHistoryByBudget(history, remainingBudget, contextWindow.countTokens)
+      : []
+    return {
+      messages: [...fixedMessages, ...selectedHistory, userMessage],
+      userTimestamp,
+    }
+  }
+
+  // 向后兼容：全量回放
+  return {
+    messages: [...fixedMessages, ...history, userMessage],
+    userTimestamp,
+  }
+}

--- a/packages/session/src/create-main-session.ts
+++ b/packages/session/src/create-main-session.ts
@@ -8,6 +8,7 @@ import type {
   IntegrateFn, IntegrateResult, CreateMainSessionOptions, LoadMainSessionOptions,
   SendResult, StreamResult,
 } from './types/functions.js'
+import { assembleMainSessionContext } from './context-utils.js'
 
 function createStreamResult(
   processor: (push: (chunk: string) => void) => Promise<SendResult>
@@ -76,30 +77,16 @@ function buildMainSession(
         throw new Error('LLMAdapter is required for send()')
       }
 
-      // 组装上下文：system prompt → synthesis → L3 历史 → 当前用户消息
-      const messages: Message[] = []
-
-      const sysPrompt = await storage.getSystemPrompt(currentMeta.id)
-      if (sysPrompt) {
-        messages.push({ role: 'system', content: sysPrompt })
-      }
-
-      const synthContent = await storage.getMemory(currentMeta.id)
-      if (synthContent) {
-        messages.push({ role: 'system', content: synthContent })
-      }
-
-      const history = await storage.listRecords(currentMeta.id)
-      messages.push(...history)
-
-      const now = new Date().toISOString()
-      messages.push({ role: 'user', content, timestamp: now })
+      // 组装上下文（含 token 预算压缩）
+      const { messages, userTimestamp } = await assembleMainSessionContext(
+        currentMeta.id, storage, content, options.contextWindow,
+      )
 
       // 调 LLM
       const result = await options.llm.complete(messages, { tools })
 
       // 存 L3：用户消息 + assistant 响应
-      const userRecord: Message = { role: 'user', content, timestamp: now }
+      const userRecord: Message = { role: 'user', content, timestamp: userTimestamp }
       const assistantRecord: Message = {
         role: 'assistant',
         content: result.content ?? '',
@@ -124,23 +111,12 @@ function buildMainSession(
       }
 
       return createStreamResult(async (push) => {
-        const messages: Message[] = []
+        // 组装上下文（含 token 预算压缩）
+        const { messages, userTimestamp } = await assembleMainSessionContext(
+          currentMeta.id, storage, content, options.contextWindow,
+        )
 
-        const sysPrompt = await storage.getSystemPrompt(currentMeta.id)
-        if (sysPrompt) {
-          messages.push({ role: 'system', content: sysPrompt })
-        }
-
-        const synthContent = await storage.getMemory(currentMeta.id)
-        if (synthContent) {
-          messages.push({ role: 'system', content: synthContent })
-        }
-
-        const history = await storage.listRecords(currentMeta.id)
-        messages.push(...history)
-
-        const now = new Date().toISOString()
-        messages.push({ role: 'user', content, timestamp: now })
+        const now = userTimestamp
 
         if (!options.llm) {
           throw new Error('LLM adapter not set. Call setLLM() first or pass llm to createMainSession().')
@@ -233,6 +209,16 @@ function buildMainSession(
       }
 
       return result
+    },
+
+    async trimRecords(keepRecent: number): Promise<void> {
+      if (keepRecent < 0) {
+        throw new Error('keepRecent must be a non-negative integer')
+      }
+      if (currentMeta.status === 'archived') {
+        throw new SessionArchivedError(currentMeta.id)
+      }
+      await storage.trimRecords(currentMeta.id, keepRecent)
     },
 
     async updateMeta(updates: SessionMetaUpdate): Promise<void> {

--- a/packages/session/src/create-session.ts
+++ b/packages/session/src/create-session.ts
@@ -4,6 +4,7 @@ import { SessionArchivedError, NotImplementedError } from './types/session-api.j
 import type { SessionMeta, SessionMetaUpdate, ForkOptions } from './types/session.js'
 import type { Message } from './types/llm.js'
 import type { ConsolidateFn, CreateSessionOptions, LoadSessionOptions, SendResult, StreamResult } from './types/functions.js'
+import { assembleSessionContext } from './context-utils.js'
 
 function createStreamResult(
   processor: (push: (chunk: string) => void) => Promise<SendResult>
@@ -72,32 +73,21 @@ function buildSession(
         throw new Error('LLMAdapter is required for send()')
       }
 
-      // 组装上下文：system prompt → insights → L3 历史 → 当前用户消息
-      const messages: Message[] = []
+      // 组装上下文（含 token 预算压缩）
+      const { messages, insightConsumed, userTimestamp } = await assembleSessionContext(
+        currentMeta.id, storage, content, options.contextWindow,
+      )
 
-      const sysPrompt = await storage.getSystemPrompt(currentMeta.id)
-      if (sysPrompt) {
-        messages.push({ role: 'system', content: sysPrompt })
-      }
-
-      const insightContent = await storage.getInsight(currentMeta.id)
-      if (insightContent) {
-        messages.push({ role: 'system', content: insightContent })
-        // 消费 insight：读取后清除，避免重复出现在后续上下文中
+      // 消费 insight
+      if (insightConsumed) {
         await storage.clearInsight(currentMeta.id)
       }
-
-      const history = await storage.listRecords(currentMeta.id)
-      messages.push(...history)
-
-      const now = new Date().toISOString()
-      messages.push({ role: 'user', content, timestamp: now })
 
       // 调 LLM
       const result = await options.llm.complete(messages, { tools })
 
       // 存 L3：用户消息 + assistant 响应
-      const userRecord: Message = { role: 'user', content, timestamp: now }
+      const userRecord: Message = { role: 'user', content, timestamp: userTimestamp }
       const assistantRecord: Message = {
         role: 'assistant',
         content: result.content ?? '',
@@ -122,23 +112,17 @@ function buildSession(
       }
 
       return createStreamResult(async (push) => {
-        const messages: Message[] = []
+        // 组装上下文（含 token 预算压缩）
+        const { messages, insightConsumed, userTimestamp } = await assembleSessionContext(
+          currentMeta.id, storage, content, options.contextWindow,
+        )
 
-        const sysPrompt = await storage.getSystemPrompt(currentMeta.id)
-        if (sysPrompt) {
-          messages.push({ role: 'system', content: sysPrompt })
+        // 消费 insight
+        if (insightConsumed) {
+          await storage.clearInsight(currentMeta.id)
         }
 
-        const insightContent = await storage.getInsight(currentMeta.id)
-        if (insightContent) {
-          messages.push({ role: 'system', content: insightContent })
-        }
-
-        const history = await storage.listRecords(currentMeta.id)
-        messages.push(...history)
-
-        const now = new Date().toISOString()
-        messages.push({ role: 'user', content, timestamp: now })
+        const now = userTimestamp
 
         if (!options.llm) {
           throw new Error('LLM adapter not set. Call setLLM() first or pass llm to createSession().')
@@ -227,6 +211,16 @@ function buildSession(
       const messages = await storage.listRecords(currentMeta.id)
       const newMemory = await fn(currentMemory, messages)
       await storage.putMemory(currentMeta.id, newMemory)
+    },
+
+    async trimRecords(keepRecent: number): Promise<void> {
+      if (keepRecent < 0) {
+        throw new Error('keepRecent must be a non-negative integer')
+      }
+      if (currentMeta.status === 'archived') {
+        throw new SessionArchivedError(currentMeta.id)
+      }
+      await storage.trimRecords(currentMeta.id, keepRecent)
     },
 
     async fork(forkOptions: ForkOptions): Promise<Session> {

--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -30,6 +30,8 @@ export type {
   LoadMainSessionOptions,
   SendResult,
   StreamResult,
+  ContextWindowOptions,
+  CountTokensFn,
 } from './types/functions.js'
 
 // 工具工厂

--- a/packages/session/src/mocks/in-memory-storage.ts
+++ b/packages/session/src/mocks/in-memory-storage.ts
@@ -63,6 +63,18 @@ export class InMemoryStorageAdapter implements MainStorage {
     return list.map((m) => ({ ...m }))
   }
 
+  /** 裁剪旧 L3，保留最近 keepRecent 条 */
+  async trimRecords(sessionId: string, keepRecent: number): Promise<void> {
+    if (keepRecent <= 0) {
+      this.records.set(sessionId, [])
+      return
+    }
+    const list = this.records.get(sessionId) ?? []
+    if (list.length > keepRecent) {
+      this.records.set(sessionId, list.slice(-keepRecent))
+    }
+  }
+
   async getSystemPrompt(sessionId: string): Promise<string | null> {
     return this.systemPrompts.get(sessionId) ?? null
   }

--- a/packages/session/src/types/functions.ts
+++ b/packages/session/src/types/functions.ts
@@ -26,6 +26,17 @@ export type IntegrateFn = (
   currentSynthesis: string | null
 ) => Promise<IntegrateResult>
 
+/** 计算消息数组的 token 数量（应用层注入，适配不同 LLM 的 tokenizer） */
+export type CountTokensFn = (messages: Message[]) => number
+
+/** 上下文窗口配置，控制 send()/stream() 的上下文压缩行为 */
+export interface ContextWindowOptions {
+  /** 上下文窗口的 token 上限（应与目标 LLM 的上下文窗口匹配） */
+  maxContextTokens: number
+  /** token 计数函数（应用层提供，适配不同 tokenizer） */
+  countTokens: CountTokensFn
+}
+
 /** createSession() 的选项 */
 export interface CreateSessionOptions {
   /** 指定存储适配器（普通 Session 只需 SessionStorage） */
@@ -42,6 +53,8 @@ export interface CreateSessionOptions {
   metadata?: Record<string, unknown>
   /** 可用工具定义 */
   tools?: LLMCompleteOptions['tools']
+  /** 上下文窗口配置（启用后按 token 预算压缩上下文） */
+  contextWindow?: ContextWindowOptions
 }
 
 /** loadSession() 的选项 */
@@ -54,6 +67,8 @@ export interface LoadSessionOptions {
   systemPrompt?: string
   /** 可用工具定义 */
   tools?: LLMCompleteOptions['tools']
+  /** 上下文窗口配置（启用后按 token 预算压缩上下文） */
+  contextWindow?: ContextWindowOptions
 }
 
 /** createMainSession() 的选项 */
@@ -72,6 +87,8 @@ export interface CreateMainSessionOptions {
   metadata?: Record<string, unknown>
   /** 可用工具定义 */
   tools?: LLMCompleteOptions['tools']
+  /** 上下文窗口配置（启用后按 token 预算压缩上下文） */
+  contextWindow?: ContextWindowOptions
 }
 
 /** loadMainSession() 的选项 */
@@ -84,6 +101,8 @@ export interface LoadMainSessionOptions {
   systemPrompt?: string
   /** 可用工具定义 */
   tools?: LLMCompleteOptions['tools']
+  /** 上下文窗口配置（启用后按 token 预算压缩上下文） */
+  contextWindow?: ContextWindowOptions
 }
 
 /** send() 的返回结果 */

--- a/packages/session/src/types/main-session-api.ts
+++ b/packages/session/src/types/main-session-api.ts
@@ -37,6 +37,9 @@ export interface MainSession {
   /** 执行 integration cycle：收集子 L2 → IntegrateFn → 保存 synthesis + 推送 insights */
   integrate(fn: IntegrateFn): Promise<IntegrateResult>
 
+  /** 裁剪旧 L3，保留最近 keepRecent 条。通常在 integrate() 后调用 */
+  trimRecords(keepRecent: number): Promise<void>
+
   /** 更新元数据 */
   updateMeta(updates: SessionMetaUpdate): Promise<void>
 

--- a/packages/session/src/types/session-api.ts
+++ b/packages/session/src/types/session-api.ts
@@ -61,6 +61,9 @@ export interface Session {
   /** L3 → L2 提炼，由上层在合适时机触发 */
   consolidate(fn: ConsolidateFn): Promise<void>
 
+  /** 裁剪旧 L3，保留最近 keepRecent 条。通常在 consolidate() 后调用 */
+  trimRecords(keepRecent: number): Promise<void>
+
   /** 派生子 Session，根据 forkRole 一次性继承父链上下文，之后独立 */
   fork(options: ForkOptions): Promise<Session>
 

--- a/packages/session/src/types/storage.ts
+++ b/packages/session/src/types/storage.ts
@@ -24,6 +24,8 @@ export interface SessionStorage {
   appendRecord(sessionId: string, record: Message): Promise<void>
   /** 读取对话记录列表（L3） */
   listRecords(sessionId: string, options?: ListRecordsOptions): Promise<Message[]>
+  /** 裁剪旧 L3 记录，仅保留最近 keepRecent 条 */
+  trimRecords(sessionId: string, keepRecent: number): Promise<void>
 
   /** 读取 Session 的 system prompt，不存在返回 null */
   getSystemPrompt(sessionId: string): Promise<string | null>


### PR DESCRIPTION
## Summary

- 为 Session/MainSession 的 `send()`/`stream()` 添加基于 token 预算的上下文压缩能力
- 应用层通过 `contextWindow: { maxContextTokens, countTokens }` 配置，适配不同 LLM 的上下文窗口和 tokenizer
- 配置后 L2（memory/synthesis）作为摘要前缀注入上下文，L3 按剩余 token 预算从最近往前填充
- 新增 `trimRecords(keepRecent)` 方法，支持 consolidate 后物理裁剪旧 L3
- 不配置 `contextWindow` 时行为完全向后兼容

## 改动范围

| 模块 | 改动 |
|------|------|
| `types/functions.ts` | 新增 `CountTokensFn`、`ContextWindowOptions`，四个 Options 均添加 `contextWindow?` |
| `types/storage.ts` | `SessionStorage` 新增 `trimRecords()` |
| `types/session-api.ts` / `main-session-api.ts` | Session/MainSession 新增 `trimRecords()` |
| `context-utils.ts` | **新文件** — 共享的上下文组装逻辑（`selectHistoryByBudget`、`assembleSessionContext`、`assembleMainSessionContext`） |
| `create-session.ts` / `create-main-session.ts` | 重构 send()/stream() 使用共享上下文组装，添加 trimRecords 实现 |
| `in-memory-storage.ts` | 实现 `trimRecords` |
| `pg-session-storage.ts` | 实现 `trimRecords`（SQL） |

## 设计决策

- **放宽 L2 可见性约束**：配置 `contextWindow` 时，L2 作为压缩前缀注入子 Session 的 send() 上下文（原约束为「L2 对子 Session 不可见」）
- **增量 token 计数**：O(n) 算法，逐条累加而非 O(n²) 重新计数
- **countTokens 回调注入**：不内置 tokenizer，应用层适配不同 LLM

## Test plan

- [x] 现有 78 个测试全部通过（向后兼容）
- [x] 新增 15 个测试覆盖：trimRecords 存储操作、token 预算压缩、边界条件（负数/超预算/空历史）、consolidate+trim 工作流、MainSession 压缩、stream 压缩
- [x] session 包 build 通过（ESM + CJS + DTS）
- [x] core 包 build 通过