### PR TITLE
fix(session): 提高 openai 兼容适配器默认输出上限

### DIFF
--- a/packages/session/src/__tests__/openai-compatible.test.ts
+++ b/packages/session/src/__tests__/openai-compatible.test.ts
@@ -45,6 +45,23 @@ describe('createOpenAICompatibleAdapter', () => {
         { role: 'system', content: 'system prompt\n\nsynthesis' },
         { role: 'user', content: 'hello' },
       ],
+      max_tokens: 4096,
+      stream: false,
+    }))
+  })
+
+  it('显式传入 maxTokens 时优先使用调用方配置', async () => {
+    const adapter = createOpenAICompatibleAdapter({
+      apiKey: 'test-key',
+      baseURL: 'https://api.example.com/v1',
+      model: 'test-model',
+      maxContextTokens: 128_000,
+    })
+
+    await adapter.complete([{ role: 'user', content: 'hello' }], { maxTokens: 2048 })
+
+    expect(createCompletion).toHaveBeenCalledWith(expect.objectContaining({
+      max_tokens: 2048,
       stream: false,
     }))
   })

--- a/packages/session/src/adapters/openai-compatible.ts
+++ b/packages/session/src/adapters/openai-compatible.ts
@@ -46,7 +46,7 @@ export function createOpenAICompatibleAdapter(options: OpenAICompatibleOptions):
     const normalizedMessages = mergeConsecutiveSystemMessages(messages)
     return {
       model: options.model,
-      max_tokens: completeOptions?.maxTokens ?? 1024,
+      max_tokens: completeOptions?.maxTokens ?? 4096,
       ...(completeOptions?.temperature !== undefined && { temperature: completeOptions.temperature }),
       ...(completeOptions?.tools
         ? {


### PR DESCRIPTION
## 概述

修复 OpenAI 兼容适配器在未显式传入 `maxTokens` 时默认输出上限过低的问题，避免推理模型在带 `<think>` 和 tool call 的场景下更容易因为输出预算不足而截断响应。

## 改动类型

请勾选适用的类型：

- [x] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档更新
- [ ] ♻️ 代码重构
- [ ] ⚡️ 性能优化
- [x] ✅ 测试相关
- [ ] 🔧 构建/配置

## 改动内容

- 将 `createOpenAICompatibleAdapter` 的默认 `max_tokens` 从 `1024` 提升到 `4096`
- 保持调用方显式传入 `maxTokens` 时仍优先使用调用方配置
- 为默认值和覆盖行为补充单元测试

## Changeset 确认 ⚠️

请确认以下其中一项：

- [ ] **已添加 changeset**（功能代码改动）
  - Changeset 文件路径：`.changeset/___-___-___.md`
  - 影响的包：`@stello-ai/session`
  - 版本类型：patch

- [ ] **不需要 changeset**（以下情况勾选）
  - [ ] 仅修改文档（README、注释、.md 文件）
  - [ ] 仅修改测试代码
  - [ ] 仅修改 CI/CD 配置

## Changeset 格式检查

如果你添加了 changeset，请确认：

- [ ] 包名使用完整格式（如 `"@stello-ai/core"` 而不是 `"core"`）
- [ ] 版本类型正确（patch/minor/major）
- [ ] 描述清晰，面向用户（会出现在 CHANGELOG 中）
- [ ] 使用推荐格式：`feat(模块): 功能描述` 或 `fix(模块): 问题描述`

## 测试

- [x] 添加了单元测试
- [ ] 添加了集成测试（如需要）
- [ ] 本地测试全部通过（`pnpm test`）
- [ ] 类型检查通过（`pnpm typecheck`）

## 提交前检查清单

- [ ] 代码已通过 `pnpm typecheck`
- [ ] 代码已通过 `pnpm lint`
- [ ] 代码已通过 `pnpm test`
- [ ] 已添加必要的 changeset 或确认不需要
- [ ] Changeset 格式正确（如已添加）
- [x] Commit 消息符合规范（`feat/fix/docs/test/chore(scope): 描述`）
- [ ] 文档已更新（如需要）

## 相关 Issue

Closes # [18](https://github.com/stello-agent/stello/issues/18)

---

📖 **贡献指南**：请查看 [CONTRIBUTING.md](https://github.com/stello-agent/stello/blob/main/CONTRIBUTING.md) 了解详细的贡献流程。
