### PR TITLE
fix(topology): 显示 fork 来源节点

### DIFF
--- a/demo/stello-agent-chat/chat-devtools.ts
+++ b/demo/stello-agent-chat/chat-devtools.ts
@@ -135,6 +135,7 @@ interface ChildSessionBootstrapOptions {
   scope?: string
   systemPrompt?: string
   prompt?: string
+  metadata?: Record<string, unknown>
 }
 
 type WrappedSession = { session: Session; main?: never }
@@ -321,6 +322,7 @@ async function createDemoChildSession(
     parentId: options.parentId,
     label: options.label,
     scope: options.scope,
+    metadata: options.metadata,
   })
   const childSession = await registerStandardSession(
     fs,
@@ -617,6 +619,7 @@ async function bootstrap() {
           parentId: options.parentId,
           label: options.label,
           scope: options.scope,
+          metadata: options.metadata,
         },
       )
     },
@@ -655,6 +658,7 @@ async function bootstrap() {
                 label: forkOptions.label,
                 systemPrompt: forkOptions.systemPrompt ?? await parentSession.systemPrompt() ?? undefined,
                 prompt: forkOptions.prompt,
+                metadata: { sourceSessionId: currentToolSessionId },
               },
             )
             const childEntry = sessionMap.get(child.id)

--- a/packages/core/src/agent/__tests__/stello-agent.test.ts
+++ b/packages/core/src/agent/__tests__/stello-agent.test.ts
@@ -204,6 +204,7 @@ describe('StelloAgent', () => {
     expect(prepareChildSpawn).toHaveBeenCalledWith({
       label: 'UI 2',
       scope: 'ui',
+      metadata: { sourceSessionId: 'child-1' },
       parentId: 'root',
     });
     expect(result.parentId).toBe('root');

--- a/packages/core/src/orchestrator/__tests__/session-orchestrator.test.ts
+++ b/packages/core/src/orchestrator/__tests__/session-orchestrator.test.ts
@@ -111,7 +111,11 @@ describe('SessionOrchestrator', () => {
     const orchestrator = new SessionOrchestrator(sessions, runtimeManager as never);
     const result = await orchestrator.forkSession('s1', { label: 'UI', scope: 'ui' });
 
-    expect(engine.forkSession).toHaveBeenCalledWith({ label: 'UI', scope: 'ui' });
+    expect(engine.forkSession).toHaveBeenCalledWith({
+      label: 'UI',
+      scope: 'ui',
+      metadata: { sourceSessionId: 's1' },
+    });
     expect(result.id).toBe('child-1');
   });
 
@@ -148,7 +152,11 @@ describe('SessionOrchestrator', () => {
       'root',
       expect.stringContaining('orchestrator:root:'),
     );
-    expect(rootEngine.forkSession).toHaveBeenCalledWith({ label: 'UI 2', scope: 'ui' });
+    expect(rootEngine.forkSession).toHaveBeenCalledWith({
+      label: 'UI 2',
+      scope: 'ui',
+      metadata: { sourceSessionId: 'child-1' },
+    });
     expect(result.parentId).toBe('root');
   });
 

--- a/packages/core/src/orchestrator/session-orchestrator.ts
+++ b/packages/core/src/orchestrator/session-orchestrator.ts
@@ -163,7 +163,13 @@ export class SessionOrchestrator {
     const effectiveParentId = await this.strategy.resolveForkParent(node, this.sessions);
 
     return this.runSerial(effectiveParentId, async () => {
-      return this.withRuntime(effectiveParentId, (engine) => engine.forkSession(options));
+      return this.withRuntime(effectiveParentId, (engine) => engine.forkSession({
+        ...options,
+        metadata: {
+          ...(options.metadata ?? {}),
+          sourceSessionId: sessionId,
+        },
+      }));
     });
   }
 

--- a/packages/core/src/session/__tests__/session-tree.test.ts
+++ b/packages/core/src/session/__tests__/session-tree.test.ts
@@ -164,7 +164,7 @@ describe('SessionTreeImpl', () => {
     const root = await tree.createRoot('根');
     const a = await tree.createChild({ parentId: root.id, label: 'A' });
     const b = await tree.createChild({ parentId: root.id, label: 'B' });
-    await tree.createChild({ parentId: a.id, label: 'A1' });
+    await tree.createChild({ parentId: a.id, label: 'A1', metadata: { sourceSessionId: a.id } });
 
     const treeData = await tree.getTree();
     expect(treeData.id).toBe(root.id);
@@ -176,6 +176,7 @@ describe('SessionTreeImpl', () => {
     expect(childA?.label).toBe('A');
     expect(childA?.children).toHaveLength(1);
     expect(childA?.children[0]?.label).toBe('A1');
+    expect(childA?.children[0]?.sourceSessionId).toBe(a.id);
 
     const childB = treeData.children.find((c) => c.id === b.id);
     expect(childB?.label).toBe('B');

--- a/packages/core/src/session/session-tree.ts
+++ b/packages/core/src/session/session-tree.ts
@@ -215,6 +215,9 @@ export class SessionTreeImpl implements SessionTree {
     const buildNode = (stored: StoredMeta): SessionTreeNode => ({
       id: stored.id,
       label: stored.label,
+      sourceSessionId: typeof stored.metadata?.['sourceSessionId'] === 'string'
+        ? stored.metadata['sourceSessionId'] as string
+        : undefined,
       status: stored.status,
       turnCount: stored.turnCount,
       children: stored.children

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -64,6 +64,8 @@ export interface SessionTreeNode {
   id: string;
   /** 显示名称 */
   label: string;
+  /** 展示层的 fork 来源 Session ID */
+  sourceSessionId?: string;
   /** 当前状态 */
   status: SessionStatus;
   /** 对话轮次数 */

--- a/packages/devtools/web/src/lib/api.ts
+++ b/packages/devtools/web/src/lib/api.ts
@@ -20,6 +20,7 @@ export interface SessionMeta {
 export interface SessionTreeNode {
   id: string
   label: string
+  sourceSessionId?: string
   status: 'active' | 'archived'
   turnCount: number
   children: SessionTreeNode[]

--- a/packages/devtools/web/src/pages/Topology.tsx
+++ b/packages/devtools/web/src/pages/Topology.tsx
@@ -56,6 +56,7 @@ interface TopoNode {
   id: string
   label: string
   parentId: string | null
+  sourceSessionId?: string
   status: 'active' | 'archived'
   turns: number
   children: string[]
@@ -151,13 +152,21 @@ function computeLayout(nodes: TopoNode[], width: number, height: number, theme: 
   return result
 }
 
+/** 展示层优先使用 fork 来源，否则退回逻辑父节点。 */
+function getDisplayParentId(node: Pick<TopoNode, 'id' | 'parentId' | 'sourceSessionId'>): string | null {
+  if (node.sourceSessionId && node.sourceSessionId !== node.id) {
+    return node.sourceSessionId
+  }
+  return node.parentId
+}
+
 /** 判断节点是否与 highlightedId 相邻 */
 function isAdjacent(node: LayoutNode, highlightedId: string | null, nodeMap: Map<string, LayoutNode>): boolean {
   if (!highlightedId) return false
   if (node.id === highlightedId) return true
-  if (node.parentId === highlightedId) return true
+  if (getDisplayParentId(node) === highlightedId) return true
   const highlighted = nodeMap.get(highlightedId)
-  if (highlighted?.parentId === node.id) return true
+  if (highlighted && getDisplayParentId(highlighted) === node.id) return true
   if (node.refs.includes(highlightedId)) return true
   if (highlighted?.refs.includes(node.id)) return true
   return false
@@ -189,8 +198,9 @@ function renderFrame(
 
   /* 画父子连线 */
   for (const node of nodes) {
-    if (!node.parentId) continue
-    const parent = nodeMap.get(node.parentId)
+    const displayParentId = getDisplayParentId(node)
+    if (!displayParentId) continue
+    const parent = nodeMap.get(displayParentId)
     if (!parent) continue
 
     const adjacent = hasHighlight && (
@@ -203,7 +213,7 @@ function renderFrame(
     ctx.strokeStyle = adjacent
       ? colors.lineHighlight
       : hasHighlight ? colors.lineDim : colors.lineColor
-    ctx.lineWidth = adjacent ? 3 : parent.parentId === null ? 2.5 : 1.5
+    ctx.lineWidth = adjacent ? 3 : getDisplayParentId(parent) === null ? 2.5 : 1.5
     ctx.shadowColor = adjacent ? colors.lineColor : colors.lineDim
     ctx.shadowBlur = adjacent ? 12 : 8
     ctx.stroke()
@@ -286,7 +296,8 @@ function renderFrame(
     ctx.globalAlpha = 1
 
     /* 节点标签 */
-    ctx.font = `${node.parentId === null ? '600' : '500'} ${node.parentId === null ? 11 : 9}px Outfit, system-ui`
+    const isMain = getDisplayParentId(node) === null
+    ctx.font = `${isMain ? '600' : '500'} ${isMain ? 11 : 9}px Outfit, system-ui`
     ctx.fillStyle = node.color
     ctx.globalAlpha = dimmed ? 0.2 : node.status === 'archived' ? 0.5 : colors.labelAlpha
     ctx.textAlign = 'left'
@@ -375,14 +386,29 @@ export function Topology() {
         id: node.id,
         label: node.label,
         parentId,
+        sourceSessionId: node.sourceSessionId,
         status: node.status,
         turns: node.turnCount ?? 0,
-        children: node.children.map((c) => c.id),
+        children: [],
         refs: [],
       }
       return [topo, ...node.children.flatMap((c) => flatten(c, node.id))]
     }
-    return flatten(tree, null)
+    const flatNodes = flatten(tree, null)
+    const displayChildren = new Map<string, string[]>()
+
+    for (const node of flatNodes) {
+      const displayParentId = getDisplayParentId(node)
+      if (!displayParentId) continue
+      const siblings = displayChildren.get(displayParentId) ?? []
+      siblings.push(node.id)
+      displayChildren.set(displayParentId, siblings)
+    }
+
+    return flatNodes.map((node) => ({
+      ...node,
+      children: displayChildren.get(node.id) ?? [],
+    }))
   }, [])
 
   /** 拉取并刷新拓扑树 */

--- a/packages/server/src/__tests__/pg-session-tree.test.ts
+++ b/packages/server/src/__tests__/pg-session-tree.test.ts
@@ -115,7 +115,7 @@ describe('PgSessionTree', () => {
     it('返回递归树结构', async () => {
       const root = await tree.createRoot('Root')
       const c1 = await tree.createChild({ parentId: root.id, label: 'C1' })
-      await tree.createChild({ parentId: c1.id, label: 'C1.1' })
+      await tree.createChild({ parentId: c1.id, label: 'C1.1', metadata: { sourceSessionId: c1.id } })
       await tree.createChild({ parentId: root.id, label: 'C2' })
 
       const sessionTree = await tree.getTree()
@@ -125,6 +125,7 @@ describe('PgSessionTree', () => {
       expect(sessionTree.children[0]!.label).toBe('C1')
       expect(sessionTree.children[0]!.children).toHaveLength(1)
       expect(sessionTree.children[0]!.children[0]!.label).toBe('C1.1')
+      expect(sessionTree.children[0]!.children[0]!.sourceSessionId).toBe(c1.id)
       expect(sessionTree.children[1]!.label).toBe('C2')
     })
   })

--- a/packages/server/src/storage/pg-session-tree.ts
+++ b/packages/server/src/storage/pg-session-tree.ts
@@ -226,7 +226,7 @@ export class PgSessionTree implements SessionTree {
   /** 获取完整递归树 */
   async getTree(): Promise<SessionTreeNode> {
     const { rows } = await this.client.query(
-      'SELECT id, parent_id, label, status FROM sessions WHERE space_id = $1 ORDER BY depth ASC, "index" ASC',
+      'SELECT id, parent_id, label, status, turn_count, metadata FROM sessions WHERE space_id = $1 ORDER BY depth ASC, "index" ASC',
       [this.spaceId],
     )
 
@@ -237,6 +237,9 @@ export class PgSessionTree implements SessionTree {
       const node: SessionTreeNode = {
         id: row['id'] as string,
         label: row['label'] as string,
+        sourceSessionId: typeof (row['metadata'] as Record<string, unknown> | null)?.['sourceSessionId'] === 'string'
+          ? (row['metadata'] as Record<string, unknown>)['sourceSessionId'] as string
+          : undefined,
         status: row['status'] as 'active' | 'archived',
         turnCount: (row['turn_count'] as number) ?? 0,
         children: [],


### PR DESCRIPTION
## 概述

为 fork 出来的子会话补充展示来源信息，让拓扑图在保持现有 flat 编排逻辑不变的前提下，能够显示“这个节点是从哪个子会话裂变出来的”。

## 改动类型

请勾选适用的类型：

- [x] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档更新
- [ ] ♻️ 代码重构
- [ ] ⚡️ 性能优化
- [x] ✅ 测试相关
- [ ] 🔧 构建/配置

## 改动内容

- 在 fork 路径中写入 `metadata.sourceSessionId`，记录展示层的来源 session
- 在 core/server 的 `getTree()` 返回中透出 `sourceSessionId`
- 调整 devtools 拓扑图渲染，优先按 `sourceSessionId` 构建展示父子关系，保留 `parentId` 作为逻辑父节点兜底
- 修复 demo 中 `prepareChildSpawn` 和 `stello_create_session` 路径未透传 metadata，导致本地验证链路失效的问题
- 补充 core/server 相关测试，覆盖 fork 来源写入和 tree 透出场景

## Changeset 确认 ⚠️

请确认以下其中一项：

- [ ] **已添加 changeset**（功能代码改动）
  - Changeset 文件路径：`.changeset/___-___-___.md`
  - 影响的包：`@stello-ai/core`, `@stello-ai/server`, `@stello-ai/devtools`
  - 版本类型：patch

- [ ] **不需要 changeset**（以下情况勾选）
  - [ ] 仅修改文档（README、注释、.md 文件）
  - [ ] 仅修改测试代码
  - [ ] 仅修改 CI/CD 配置

## Changeset 格式检查

如果你添加了 changeset，请确认：

- [ ] 包名使用完整格式（如 `"@stello-ai/core"` 而不是 `"core"`）
- [ ] 版本类型正确（patch/minor/major）
- [ ] 描述清晰，面向用户（会出现在 CHANGELOG 中）
- [ ] 使用推荐格式：`feat(模块): 功能描述` 或 `fix(模块): 问题描述`

## 测试

- [x] 添加了单元测试
- [ ] 添加了集成测试（如需要）
- [ ] 本地测试全部通过（`pnpm test`）
- [ ] 类型检查通过（`pnpm typecheck`）

## 提交前检查清单

- [ ] 代码已通过 `pnpm typecheck`
- [ ] 代码已通过 `pnpm lint`
- [ ] 代码已通过 `pnpm test`
- [ ] 已添加必要的 changeset 或确认不需要
- [ ] Changeset 格式正确（如已添加）
- [x] Commit 消息符合规范（`feat/fix/docs/test/chore(scope): 描述`）
- [ ] 文档已更新（如需要）

## 相关 Issue

Closes # [20](https://github.com/stello-agent/stello/issues/20)

---

📖 **贡献指南**：请查看 [CONTRIBUTING.md](https://github.com/stello-agent/stello/blob/main/CONTRIBUTING.md) 了解详细的贡献流程。
