### PR TITLE
fix(devtools): 持久化拓扑拖拽位置

### DIFF
--- a/packages/devtools/web/src/pages/Topology.tsx
+++ b/packages/devtools/web/src/pages/Topology.tsx
@@ -73,6 +73,35 @@ interface LayoutNode extends TopoNode {
   brightness: number
 }
 
+type SavedNodePositions = Record<string, { x: number; y: number }>
+
+const NODE_POSITION_STORAGE_KEY = 'stello-devtools-topology-node-positions'
+
+/** 从 localStorage 读取已保存的节点位置。 */
+function readSavedNodePositions(): SavedNodePositions {
+  if (typeof window === 'undefined') return {}
+  try {
+    const raw = window.localStorage.getItem(NODE_POSITION_STORAGE_KEY)
+    if (!raw) return {}
+    const parsed = JSON.parse(raw) as Record<string, { x?: unknown; y?: unknown }>
+    return Object.fromEntries(
+      Object.entries(parsed).flatMap(([id, point]) => (
+        typeof point?.x === 'number' && typeof point?.y === 'number'
+          ? [[id, { x: point.x, y: point.y }]]
+          : []
+      )),
+    )
+  } catch {
+    return {}
+  }
+}
+
+/** 持久化节点位置到 localStorage。 */
+function writeSavedNodePositions(positions: SavedNodePositions): void {
+  if (typeof window === 'undefined') return
+  window.localStorage.setItem(NODE_POSITION_STORAGE_KEY, JSON.stringify(positions))
+}
+
 /* 无 mock 数据——全部从 API 拉取 */
 
 /** 深色主题的节点颜色 */
@@ -353,6 +382,7 @@ export function Topology() {
   const [panelDetail, setPanelDetail] = useState<SessionDetail | null>(null)
   const [ctxMenu, setCtxMenu] = useState<ContextMenuState>({ visible: false, x: 0, y: 0, nodeId: null, nodeLabel: '' })
   const [actionLoading, setActionLoading] = useState(false)
+  const [savedPositions, setSavedPositions] = useState<SavedNodePositions>(() => readSavedNodePositions())
   const navigate = useNavigate()
   const { t } = useI18n()
   const { theme } = useTheme()
@@ -378,6 +408,7 @@ export function Topology() {
   const themeRef = useRef(theme)
   useEffect(() => { highlightedRef.current = highlighted }, [highlighted])
   useEffect(() => { themeRef.current = theme }, [theme])
+  useEffect(() => { writeSavedNodePositions(savedPositions) }, [savedPositions])
 
   /** 递归展平树 */
   const flattenTree = useCallback((tree: SessionTreeNode): TopoNode[] => {
@@ -465,9 +496,12 @@ export function Topology() {
     }
     prevNodeIds.current = currentIds
 
-    const layout = computeLayout(topoNodes, size.width, size.height, theme)
+    const layout = computeLayout(topoNodes, size.width, size.height, theme).map((node) => {
+      const saved = savedPositions[node.id]
+      return saved ? { ...node, x: saved.x, y: saved.y } : node
+    })
     nodesRef.current = layout
-  }, [size, topoNodes, theme])
+  }, [savedPositions, size, topoNodes, theme])
 
   /* rAF 动画循环——读 cameraRef，带惯性衰减 */
   useEffect(() => {
@@ -595,6 +629,7 @@ export function Topology() {
   /* mouseup */
   const handleMouseUp = useCallback(() => {
     const drag = dragRef.current
+    const draggedNodeId = drag.draggingNodeId
     if (drag.active && !drag.hasMoved) {
       /* 点击（没有拖动） */
       if (drag.draggingNodeId) {
@@ -607,6 +642,14 @@ export function Topology() {
         }
       } else {
         setPanelOpen(false)
+      }
+    } else if (drag.active && drag.hasMoved && draggedNodeId) {
+      const node = nodesRef.current.find((candidate) => candidate.id === draggedNodeId)
+      if (node) {
+        setSavedPositions((prev) => ({
+          ...prev,
+          [draggedNodeId]: { x: node.x, y: node.y },
+        }))
       }
     }
     drag.active = false


### PR DESCRIPTION
## 概述

修复 DevTools 拓扑图中节点拖拽位置在页面切换后丢失的问题。现在用户手动调整过的位置会在前端本地持久化，返回拓扑页后继续保持。

## 改动类型

请勾选适用的类型：

- [x] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档更新
- [ ] ♻️ 代码重构
- [ ] ⚡️ 性能优化
- [ ] ✅ 测试相关
- [ ] 🔧 构建/配置

## 改动内容

- 为拓扑页节点位置增加 `localStorage` 持久化
- 页面重新进入时优先恢复用户手动拖拽过的节点位置
- 保持自动布局逻辑不变，仅对已保存位置的节点做覆盖

## Changeset 确认 ⚠️

请确认以下其中一项：

- [ ] **已添加 changeset**（功能代码改动）
  - Changeset 文件路径：`.changeset/___-___-___.md`
  - 影响的包：`@stello-ai/devtools`
  - 版本类型：patch

- [ ] **不需要 changeset**（以下情况勾选）
  - [ ] 仅修改文档（README、注释、.md 文件）
  - [ ] 仅修改测试代码
  - [ ] 仅修改 CI/CD 配置

## Changeset 格式检查

如果你添加了 changeset，请确认：

- [ ] 包名使用完整格式（如 `"@stello-ai/core"` 而不是 `"core"`）
- [ ] 版本类型正确（patch/minor/major）
- [ ] 描述清晰，面向用户（会出现在 CHANGELOG 中）
- [ ] 使用推荐格式：`feat(模块): 功能描述` 或 `fix(模块): 问题描述`

## 测试

- [ ] 添加了单元测试
- [ ] 添加了集成测试（如需要）
- [ ] 本地测试全部通过（`pnpm test`）
- [ ] 类型检查通过（`pnpm typecheck`）

## 提交前检查清单

- [ ] 代码已通过 `pnpm typecheck`
- [ ] 代码已通过 `pnpm lint`
- [ ] 代码已通过 `pnpm test`
- [ ] 已添加必要的 changeset 或确认不需要
- [ ] Changeset 格式正确（如已添加）
- [x] Commit 消息符合规范（`feat/fix/docs/test/chore(scope): 描述`）
- [ ] 文档已更新（如需要）

## 相关 Issue

Closes # [21](https://github.com/stello-agent/stello/issues/21)

---

📖 **贡献指南**：请查看 [CONTRIBUTING.md](https://github.com/stello-agent/stello/blob/main/CONTRIBUTING.md) 了解详细的贡献流程。
