### PR TITLE
chore(devtools): cleanup

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -46,4 +46,4 @@ pnpm demo:chat
 
 说明文档：
 
-- [stello-agent-chat/README.md](/Users/bytedance/Github/stello/demo/stello-agent-chat/README.md)
+- [stello-agent-chat/README.md](./stello-agent-chat/README.md)

--- a/demo/stello-agent-chat/chat-devtools.ts
+++ b/demo/stello-agent-chat/chat-devtools.ts
@@ -957,6 +957,9 @@ async function main() {
       currentApp = await bootstrap()
       console.log('[Reset] demo reinitialized')
     },
+    getDataDir() {
+      return dataDirAbs
+    },
   }
 
   const devtoolsPort = Number(process.env.DEVTOOLS_PORT ?? 4800)

--- a/docs/stello-usage.md
+++ b/docs/stello-usage.md
@@ -143,8 +143,8 @@ const agent = createStelloAgent({
 
 更详细的配置说明见：
 
-- [config-design.md](/Users/bytedance/Github/stello/docs/config-design.md)
-- [stello-agent-config.template.ts](/Users/bytedance/Github/stello/docs/stello-agent-config.template.ts)
+- [config-design.md](./config-design.md)
+- [stello-agent-config.template.ts](./stello-agent-config.template.ts)
 
 ---
 
@@ -185,7 +185,7 @@ const agent = createStelloAgent({
 
 更完整的 API 说明见：
 
-- [stello-agent-api.md](/Users/bytedance/Github/stello/docs/stello-agent-api.md)
+- [stello-agent-api.md](./stello-agent-api.md)
 
 ---
 
@@ -228,8 +228,8 @@ StelloAgent
 
 更多说明见：
 
-- [orchestrator-usage.md](/Users/bytedance/Github/stello/docs/orchestrator-usage.md)
-- [orchestrator-strategies.md](/Users/bytedance/Github/stello/docs/orchestrator-strategies.md)
+- [orchestrator-usage.md](./orchestrator-usage.md)
+- [orchestrator-strategies.md](./orchestrator-strategies.md)
 
 ---
 
@@ -319,7 +319,7 @@ LLM 调用 `stello_create_session` 工具时，自动 fork 出子 Session 并返
 
 更多 Session 设计细节见：
 
-- [session-usage.md](/Users/bytedance/Github/stello/docs/session-usage.md)
+- [session-usage.md](./session-usage.md)
 
 ---
 
@@ -384,8 +384,8 @@ OPENAI_API_KEY=fake DEMO_DRY_RUN=1 node --import tsx demo/stello-agent-chat/chat
 
 相关设计见：
 
-- [server-package-plan.md](/Users/bytedance/Github/stello/docs/server-package-plan.md)
-- [server-ws-connection-model.md](/Users/bytedance/Github/stello/docs/server-ws-connection-model.md)
+- [server-package-plan.md](./server-package-plan.md)
+- [server-ws-connection-model.md](./server-ws-connection-model.md)
 
 ---
 
@@ -394,10 +394,10 @@ OPENAI_API_KEY=fake DEMO_DRY_RUN=1 node --import tsx demo/stello-agent-chat/chat
 如果你是第一次接触这个仓库，建议按这个顺序：
 
 1. 先看这篇总览
-2. 再看 [stello-agent-api.md](/Users/bytedance/Github/stello/docs/stello-agent-api.md)
-3. 再看 [config-design.md](/Users/bytedance/Github/stello/docs/config-design.md)
-4. 需要理解编排时，再看 [orchestrator-usage.md](/Users/bytedance/Github/stello/docs/orchestrator-usage.md)
-5. 需要理解长期目标时，再看 [sdk-final-vision.md](/Users/bytedance/Github/stello/docs/sdk-final-vision.md)
+2. 再看 [stello-agent-api.md](./stello-agent-api.md)
+3. 再看 [config-design.md](./config-design.md)
+4. 需要理解编排时，再看 [orchestrator-usage.md](./orchestrator-usage.md)
+5. 需要理解长期目标时，再看 [sdk-final-vision.md](./sdk-final-vision.md)
 
 ---
 

--- a/docs/superpowers/plans/2026-03-24-devtools-phase1.md
+++ b/docs/superpowers/plans/2026-03-24-devtools-phase1.md
@@ -148,7 +148,7 @@ export type { DevtoolsOptions } from './server/types.js'
 
 - [ ] **Step 5: pnpm install 验证包结构**
 
-Run: `cd /Users/bytedance/Github/stello && pnpm install`
+Run: `pnpm install`
 Expected: 无报错，packages/devtools 被识别
 
 - [ ] **Step 6: Commit**

--- a/packages/devtools/src/server/routes.ts
+++ b/packages/devtools/src/server/routes.ts
@@ -627,6 +627,11 @@ export function createRoutes(
     return c.json({ ok: true })
   })
 
+  /** 获取 devtools 运行时信息（如数据目录路径） */
+  app.get('/info', (c) => {
+    return c.json({ dataDir: resetProvider?.getDataDir?.() ?? null })
+  })
+
   /** 获取事件历史 */
   app.get('/events', (c) => {
     const events = getEventHistory?.() ?? []

--- a/packages/devtools/src/server/types.ts
+++ b/packages/devtools/src/server/types.ts
@@ -65,6 +65,8 @@ export interface IntegrationProvider {
 /** 清空数据并重新初始化运行时。 */
 export interface ResetProvider {
   reset(): Promise<void>
+  /** 返回数据目录的绝对路径，供前端展示 */
+  getDataDir?(): string
 }
 
 /** DevTools 可持久化的全局状态 */

--- a/packages/devtools/web/src/lib/api.ts
+++ b/packages/devtools/web/src/lib/api.ts
@@ -348,3 +348,8 @@ export function triggerIntegration() {
     method: 'POST',
   })
 }
+
+/** 获取 devtools 运行时信息 */
+export function fetchInfo() {
+  return request<{ dataDir: string | null }>('/info')
+}

--- a/packages/devtools/web/src/lib/i18n.ts
+++ b/packages/devtools/web/src/lib/i18n.ts
@@ -197,10 +197,10 @@ const dict: Record<string, Record<Locale, string>> = {
   'settings.hooks.none': { en: 'No hooks registered', zh: '未注册钩子' },
   'settings.reset.title': { en: 'Start Over', zh: '从头开始' },
   'settings.reset.desc': { en: 'Clear all demo data and reinitialize the running app from scratch.', zh: '清空当前 demo 的全部数据，并重新初始化运行中的应用。' },
-  'settings.reset.warning': { en: 'Danger zone: this will permanently delete all demo data under /Users/bytedance/Github/stello/tmp/stello-agent-chat.', zh: '危险操作：这会永久删除目录 /Users/bytedance/Github/stello/tmp/stello-agent-chat 下的全部 demo 数据。' },
+  'settings.reset.warning': { en: 'Danger zone: this will permanently delete all demo data under {dataDir}.', zh: '危险操作：这会永久删除目录 {dataDir} 下的全部 demo 数据。' },
   'settings.reset.button': { en: 'Delete all data and start over', zh: '清空全部数据并从头开始' },
   'settings.reset.confirmTitle': { en: 'Clear all data and start over?', zh: '确认清空数据并重新开始？' },
-  'settings.reset.confirmBody': { en: 'This will delete all sessions, records, prompts, and runtime state under /Users/bytedance/Github/stello/tmp/stello-agent-chat, then bootstrap a fresh demo.\n\nThis action cannot be undone.', zh: '这会删除目录 /Users/bytedance/Github/stello/tmp/stello-agent-chat 中的全部会话、记录、提示词和运行时状态，然后重新初始化一个全新的 demo。\n\n此操作不可撤销。' },
+  'settings.reset.confirmBody': { en: 'This will delete all sessions, records, prompts, and runtime state under {dataDir}, then bootstrap a fresh demo.\n\nThis action cannot be undone.', zh: '这会删除目录 {dataDir} 中的全部会话、记录、提示词和运行时状态，然后重新初始化一个全新的 demo。\n\n此操作不可撤销。' },
   'settings.reset.running': { en: 'Reinitializing...', zh: '重新初始化中...' },
 }
 
@@ -208,7 +208,7 @@ const dict: Record<string, Record<Locale, string>> = {
 export interface I18nContextValue {
   locale: Locale
   setLocale: (locale: Locale) => void
-  t: (key: string) => string
+  t: (key: string, vars?: Record<string, string>) => string
 }
 
 /** 默认上下文 */
@@ -235,8 +235,10 @@ export function useI18nProvider(): I18nContextValue {
     localStorage.setItem('stello-devtools-locale', l)
   }, [])
 
-  const t = useCallback((key: string): string => {
-    return dict[key]?.[locale] ?? key
+  const t = useCallback((key: string, vars?: Record<string, string>): string => {
+    const raw = dict[key]?.[locale] ?? key
+    if (!vars) return raw
+    return raw.replace(/\{(\w+)\}/g, (_, k) => vars[k] ?? `{${k}}`)
   }, [locale])
 
   return { locale, setLocale: setAndSave, t }

--- a/packages/devtools/web/src/pages/Settings.tsx
+++ b/packages/devtools/web/src/pages/Settings.tsx
@@ -23,7 +23,7 @@ import {
   FileText,
   RotateCcw,
 } from 'lucide-react'
-import { fetchConfig, patchConfig, fetchLLMConfig, patchLLMConfig, fetchPrompts, patchPrompts, fetchTools, toggleTool, fetchSkills, toggleSkill, resetRuntime, type AgentConfig, type HotConfigPatch, type LLMConfig, type PromptsConfig, type ToolWithStatus, type SkillWithStatus } from '@/lib/api'
+import { fetchConfig, patchConfig, fetchLLMConfig, patchLLMConfig, fetchPrompts, patchPrompts, fetchTools, toggleTool, fetchSkills, toggleSkill, resetRuntime, fetchInfo, type AgentConfig, type HotConfigPatch, type LLMConfig, type PromptsConfig, type ToolWithStatus, type SkillWithStatus } from '@/lib/api'
 import { useI18n } from '@/lib/i18n'
 import { useToast } from '@/lib/toast'
 import { EditDialog, type EditField } from '@/components/EditDialog'
@@ -158,15 +158,17 @@ export function SettingsPage() {
   const [dialogSaveFn, setDialogSaveFn] = useState<(values: Record<string, string | number>) => Promise<void>>(() => async () => {})
   const [resetOpen, setResetOpen] = useState(false)
   const [resetting, setResetting] = useState(false)
+  const [dataDir, setDataDir] = useState<string | null>(null)
 
   /** 刷新设置页所有数据 */
   const refreshAll = useCallback(async () => {
-    const [nextConfig, nextLlm, nextPrompts, nextTools, nextSkills] = await Promise.all([
+    const [nextConfig, nextLlm, nextPrompts, nextTools, nextSkills, nextInfo] = await Promise.all([
       fetchConfig(),
       fetchLLMConfig().catch(() => null),
       fetchPrompts().catch(() => null),
       fetchTools().catch(() => ({ configured: false, tools: [] as ToolWithStatus[] })),
       fetchSkills().catch(() => ({ configured: false, skills: [] as SkillWithStatus[] })),
+      fetchInfo().catch(() => ({ dataDir: null })),
     ])
 
     setConfig(nextConfig)
@@ -174,6 +176,7 @@ export function SettingsPage() {
     setPromptsConfig(nextPrompts)
     setToolsList(nextTools)
     setSkillsList(nextSkills)
+    setDataDir(nextInfo.dataDir)
   }, [])
 
   /** 打开编辑 Dialog */
@@ -688,7 +691,7 @@ export function SettingsPage() {
             <p className="text-[11px] text-text-muted leading-relaxed">{t('settings.reset.desc')}</p>
             <div className="flex items-start gap-2 px-3 py-2 bg-[#FFF1F1] border border-[#F1C3C3] rounded-lg">
               <XCircle size={14} className="text-[#C84B4B] shrink-0 mt-0.5" />
-              <p className="text-[11px] leading-relaxed text-[#9F2F2F]">{t('settings.reset.warning')}</p>
+              <p className="text-[11px] leading-relaxed text-[#9F2F2F]">{t('settings.reset.warning', dataDir ? { dataDir } : undefined)}</p>
             </div>
             <button
               onClick={() => setResetOpen(true)}
@@ -711,7 +714,7 @@ export function SettingsPage() {
       <ConfirmDialog
         open={resetOpen}
         title={t('settings.reset.confirmTitle')}
-        description={t('settings.reset.confirmBody')}
+        description={t('settings.reset.confirmBody', dataDir ? { dataDir } : undefined)}
         confirmLabel={resetting ? t('settings.reset.running') : t('settings.reset.button')}
         destructive
         loading={resetting}


### PR DESCRIPTION
文档和计划文件中的绝对路径改为相对路径；devtools 的 reset 提示
文案不再硬编码机器路径，改由服务端通过 /info 接口动态下发真实
数据目录，前端 i18n 支持 {key} 插值后渲染。

## 概述

<!-- 请简要描述这个 PR 解决了什么问题或添加了什么功能 -->

## 改动类型

请勾选适用的类型：

- [ ] 🐛 Bug 修复
- [ ] ✨ 新功能
- [ ] 📝 文档更新
- [ ] ♻️ 代码重构
- [ ] ⚡️ 性能优化
- [ ] ✅ 测试相关
- [ ] 🔧 构建/配置

## 改动内容

<!-- 列出主要的改动点 -->

-
-
-

## Changeset 确认 ⚠️

<!--
功能代码改动必须添加 changeset！
运行 `pnpm changeset` 并按提示操作。
详见：https://github.com/stello-agent/stello/blob/main/CONTRIBUTING.md#️-重要pr-格式要求
-->

请确认以下其中一项：

- [ ] **已添加 changeset**（功能代码改动）
  - Changeset 文件路径：`.changeset/___-___-___.md`
  - 影响的包：
  - 版本类型：patch / minor / major

- [ ] **不需要 changeset**（以下情况勾选）
  - [ ] 仅修改文档（README、注释、.md 文件）
  - [ ] 仅修改测试代码
  - [ ] 仅修改 CI/CD 配置

## Changeset 格式检查

如果你添加了 changeset，请确认：

- [ ] 包名使用完整格式（如 `"@stello-ai/core"` 而不是 `"core"`）
- [ ] 版本类型正确（patch/minor/major）
- [ ] 描述清晰，面向用户（会出现在 CHANGELOG 中）
- [ ] 使用推荐格式：`feat(模块): 功能描述` 或 `fix(模块): 问题描述`

**正确的 changeset 示例：**

```markdown
---
"@stello-ai/core": minor
---

feat(core): 添加 Session 树深度限制配置

- 新增 `maxDepth` 配置项，防止无限递归分支
- 深度超限时抛出明确的错误提示
```

## 测试

- [ ] 添加了单元测试
- [ ] 添加了集成测试（如需要）
- [ ] 本地测试全部通过（`pnpm test`）
- [ ] 类型检查通过（`pnpm typecheck`）

## 提交前检查清单

- [ ] 代码已通过 `pnpm typecheck`
- [ ] 代码已通过 `pnpm lint`
- [ ] 代码已通过 `pnpm test`
- [ ] 已添加必要的 changeset 或确认不需要
- [ ] Changeset 格式正确（如已添加）
- [ ] Commit 消息符合规范（`feat/fix/docs/test/chore(scope): 描述`）
- [ ] 文档已更新（如需要）

## 相关 Issue

<!-- 如果解决了某个 issue，请使用 "Closes #123" 格式 -->

Closes #

---

📖 **贡献指南**：请查看 [CONTRIBUTING.md](https://github.com/stello-agent/stello/blob/main/CONTRIBUTING.md) 了解详细的贡献流程。
