### PR TITLE
feat(sync): 引入事件式增量同步链路

### DIFF
--- a/packages/core/src/adapters/session-runtime.ts
+++ b/packages/core/src/adapters/session-runtime.ts
@@ -32,8 +32,11 @@ export type SessionCompatibleConsolidateFn = (
 
 /** 结构兼容 @stello-ai/session 的 integrate 函数签名 */
 export type SessionCompatibleIntegrateFn = (
-  children: Array<{ sessionId: string; label: string; l2: string }>,
+  children: Array<{ sessionId: string; label: string; l2: string; sequence: number; timestamp: string }>,
   currentSynthesis: string | null,
+  context?: {
+    newEvents: Array<{ sessionId: string; sequence: number; timestamp: string; content: string }>;
+  },
 ) => Promise<{
   synthesis: string;
   insights: Array<{ sessionId: string; content: string }>;

--- a/packages/core/src/llm/__tests__/defaults.test.ts
+++ b/packages/core/src/llm/__tests__/defaults.test.ts
@@ -10,8 +10,20 @@ describe('createDefaultIntegrateFn', () => {
     const fn = createDefaultIntegrateFn(DEFAULT_INTEGRATE_PROMPT, llm)
 
     await fn([
-      { sessionId: 'sess-1', label: '选校', l2: '已完成第一轮筛选' },
-      { sessionId: 'sess-2', label: '文书', l2: 'PS 初稿待修改' },
+      {
+        sessionId: 'sess-1',
+        label: '选校',
+        l2: '已完成第一轮筛选',
+        sequence: 1,
+        timestamp: '2026-04-01T00:00:00.000Z',
+      },
+      {
+        sessionId: 'sess-2',
+        label: '文书',
+        l2: 'PS 初稿待修改',
+        sequence: 2,
+        timestamp: '2026-04-01T00:00:01.000Z',
+      },
     ], null)
 
     expect(llm).toHaveBeenCalledTimes(1)

--- a/packages/server/src/__tests__/helpers.ts
+++ b/packages/server/src/__tests__/helpers.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import pg from 'pg'
-import { readFileSync } from 'node:fs'
+import { readFileSync, readdirSync } from 'node:fs'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -23,7 +23,9 @@ export function createTestPool(): pg.Pool {
 /** 执行迁移 + 清空数据（每个测试文件调用一次） */
 export async function setupDatabase(pool: pg.Pool): Promise<void> {
   const migrationsDir = join(__dirname, '..', 'db', 'migrations')
-  const files = ['001_init.sql', '002_integrate_prompt.sql']
+  const files = readdirSync(migrationsDir)
+    .filter((file) => file.endsWith('.sql'))
+    .sort()
   for (const file of files) {
     const sql = readFileSync(join(migrationsDir, file), 'utf-8')
     await pool.query(sql)
@@ -33,7 +35,7 @@ export async function setupDatabase(pool: pg.Pool): Promise<void> {
 /** 清空所有表数据（每个测试用例前调用） */
 export async function cleanDatabase(pool: pg.Pool): Promise<void> {
   await pool.query(`
-    TRUNCATE users, spaces, sessions, records, session_data, session_refs, core_data CASCADE
+    TRUNCATE users, spaces, sessions, records, session_data, session_refs, core_data, session_events CASCADE
   `)
 }
 

--- a/packages/server/src/__tests__/pg-main-storage.test.ts
+++ b/packages/server/src/__tests__/pg-main-storage.test.ts
@@ -55,6 +55,38 @@ describe('PgMainStorage', () => {
       expect(l2s[0]!.label).toBe('S1')
       expect(l2s[0]!.l2).toBe('L2 for S1')
     })
+
+    it('优先返回 memory event，并暴露 sequence / timestamp', async () => {
+      const mainId = await insertSession({ role: 'main', label: 'Main' })
+      const s1 = await insertSession({ label: 'S1', parentId: mainId })
+
+      const event = await storage.appendMemoryEvent(s1, 'event L2 for S1')
+
+      const l2s = await storage.getAllSessionL2s()
+      expect(l2s).toHaveLength(1)
+      expect(l2s[0]!.l2).toBe('event L2 for S1')
+      expect(l2s[0]!.sequence).toBe(event.sequence)
+      expect(l2s[0]!.timestamp).toBeTruthy()
+    })
+  })
+
+  describe('memory events + integration cursor', () => {
+    it('支持按 integration cursor 增量读取 memory events', async () => {
+      const mainId = await insertSession({ role: 'main', label: 'Main' })
+      const s1 = await insertSession({ label: 'S1', parentId: mainId })
+      const s2 = await insertSession({ label: 'S2', parentId: mainId })
+
+      const event1 = await storage.appendMemoryEvent(s1, 'L2-A')
+      const event2 = await storage.appendMemoryEvent(s2, 'L2-B')
+
+      await storage.setIntegrationCursor(mainId, event1.sequence)
+      expect(await storage.getIntegrationCursor(mainId)).toBe(event1.sequence)
+
+      const unread = await storage.listMemoryEvents(await storage.getIntegrationCursor(mainId))
+      expect(unread).toHaveLength(1)
+      expect(unread[0]!.sequence).toBe(event2.sequence)
+      expect(unread[0]!.content).toBe('L2-B')
+    })
   })
 
   describe('listSessions', () => {

--- a/packages/server/src/__tests__/pg-session-storage.test.ts
+++ b/packages/server/src/__tests__/pg-session-storage.test.ts
@@ -177,6 +177,39 @@ describe('PgSessionStorage', () => {
     })
   })
 
+  describe('event logs', () => {
+    let sessionId: string
+
+    beforeEach(async () => {
+      sessionId = await createSession(storage)
+    })
+
+    it('memory event 追加后可读取最新事件', async () => {
+      const event1 = await storage.appendMemoryEvent(sessionId, 'first')
+      const event2 = await storage.appendMemoryEvent(sessionId, 'second')
+
+      expect(event2.sequence).toBeGreaterThan(event1.sequence)
+
+      const latest = await storage.getLatestMemoryEvent(sessionId)
+      expect(latest).not.toBeNull()
+      expect(latest!.content).toBe('second')
+      expect(latest!.sequence).toBe(event2.sequence)
+    })
+
+    it('insight event 采用追加 + cursor 消费语义', async () => {
+      await storage.appendInsightEvent(sessionId, 'insight-a')
+      await storage.appendInsightEvent(sessionId, 'insight-b')
+
+      expect(await storage.getInsight(sessionId)).toBe('insight-a\n\ninsight-b')
+
+      await storage.clearInsight(sessionId)
+      expect(await storage.getInsight(sessionId)).toBeNull()
+
+      await storage.appendInsightEvent(sessionId, 'insight-c')
+      expect(await storage.getInsight(sessionId)).toBe('insight-c')
+    })
+  })
+
   describe('transaction', () => {
     it('成功提交', async () => {
       const id = uuid()

--- a/packages/server/src/db/migrations/004_session_events.sql
+++ b/packages/server/src/db/migrations/004_session_events.sql
@@ -1,0 +1,17 @@
+-- Session 事件日志：append-only memory / insight 事件流
+CREATE TABLE IF NOT EXISTS session_events (
+  id              BIGSERIAL PRIMARY KEY,
+  space_id        UUID NOT NULL REFERENCES spaces(id) ON DELETE CASCADE,
+  stream          TEXT NOT NULL,
+  session_id      UUID NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  content         TEXT NOT NULL,
+  event_timestamp TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CHECK (stream IN ('memory', 'insight'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_session_events_stream_id
+  ON session_events(space_id, stream, id);
+
+CREATE INDEX IF NOT EXISTS idx_session_events_session_stream_id
+  ON session_events(session_id, stream, id);

--- a/packages/server/src/storage/pg-main-storage.ts
+++ b/packages/server/src/storage/pg-main-storage.ts
@@ -1,7 +1,7 @@
 import type pg from 'pg'
 import type { MainStorage, TopologyNode } from '@stello-ai/session'
 import type { SessionMeta, SessionFilter } from '@stello-ai/session'
-import type { ChildL2Summary } from '@stello-ai/session'
+import type { ChildL2Summary, EventEnvelope } from '@stello-ai/session'
 import { PgSessionStorage } from './pg-session-storage.js'
 
 /**
@@ -16,17 +16,74 @@ export class PgMainStorage extends PgSessionStorage implements MainStorage {
   /** 批量获取所有子 Session 的 L2（integration 专用） */
   async getAllSessionL2s(): Promise<ChildL2Summary[]> {
     const { rows } = await this.client.query(
-      `SELECT s.id AS "sessionId", s.label, sd.content AS l2
+      `SELECT
+         s.id AS "sessionId",
+         s.label,
+         COALESCE(ev.content, sd.content) AS l2,
+         COALESCE(ev.id, 0) AS sequence,
+         ev.event_timestamp AS "timestamp"
        FROM sessions s
-       JOIN session_data sd ON s.id = sd.session_id AND sd.key = 'memory'
-       WHERE s.space_id = $1 AND s.role = 'standard' AND s.status = 'active'`,
+       LEFT JOIN LATERAL (
+         SELECT id, content, event_timestamp
+         FROM session_events
+         WHERE space_id = $1 AND stream = 'memory' AND session_id = s.id
+         ORDER BY id DESC
+         LIMIT 1
+       ) ev ON TRUE
+       LEFT JOIN session_data sd ON s.id = sd.session_id AND sd.key = 'memory'
+       WHERE s.space_id = $1 AND s.role = 'standard' AND s.status = 'active'
+         AND (ev.id IS NOT NULL OR sd.content IS NOT NULL)`,
       [this.spaceId],
     )
     return rows.map(r => ({
       sessionId: r['sessionId'] as string,
       label: r['label'] as string,
       l2: r['l2'] as string,
+      sequence: Number(r['sequence']),
+      timestamp: r['timestamp'] ? (r['timestamp'] as Date).toISOString() : '',
     }))
+  }
+
+  /** 读取指定序号之后的 memory 事件。 */
+  async listMemoryEvents(afterSequence = 0, limit?: number): Promise<EventEnvelope[]> {
+    const params: Array<string | number> = [this.spaceId, afterSequence]
+    let sql = `SELECT id, session_id AS "sessionId", content, event_timestamp AS "timestamp"
+       FROM session_events
+       WHERE space_id = $1 AND stream = 'memory' AND id > $2
+       ORDER BY id ASC`
+
+    if (limit !== undefined) {
+      sql += ' LIMIT $3'
+      params.push(limit)
+    }
+
+    const { rows } = await this.client.query(sql, params)
+    return rows.map((row) => ({
+      sessionId: row['sessionId'] as string,
+      sequence: Number(row['id']),
+      content: row['content'] as string,
+      timestamp: (row['timestamp'] as Date).toISOString(),
+    }))
+  }
+
+  /** 读取 MainSession 的 integration cursor。 */
+  async getIntegrationCursor(sessionId: string): Promise<number> {
+    const { rows } = await this.client.query(
+      'SELECT value FROM core_data WHERE space_id = $1 AND path = $2',
+      [this.spaceId, `integration_cursor:${sessionId}`],
+    )
+    if (rows.length === 0) return 0
+    return Number(rows[0]!['value'])
+  }
+
+  /** 更新 MainSession 的 integration cursor。 */
+  async setIntegrationCursor(sessionId: string, sequence: number): Promise<void> {
+    await this.client.query(
+      `INSERT INTO core_data (space_id, path, value)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (space_id, path) DO UPDATE SET value = EXCLUDED.value`,
+      [this.spaceId, `integration_cursor:${sessionId}`, JSON.stringify(sequence)],
+    )
   }
 
   /** 列举 Session，可按条件过滤 */

--- a/packages/server/src/storage/pg-session-storage.ts
+++ b/packages/server/src/storage/pg-session-storage.ts
@@ -1,5 +1,5 @@
 import type pg from 'pg'
-import type { SessionStorage, ListRecordsOptions } from '@stello-ai/session'
+import type { EventEnvelope, SessionStorage, ListRecordsOptions } from '@stello-ai/session'
 import type { SessionMeta } from '@stello-ai/session'
 import type { Message } from '@stello-ai/session'
 
@@ -146,16 +146,30 @@ export class PgSessionStorage implements SessionStorage {
 
   /** 读取 insight */
   async getInsight(sessionId: string): Promise<string | null> {
+    const cursor = await this.getInsightCursor(sessionId)
+    const unreadEvents = await this.listInsightEvents(sessionId, cursor)
+    if (unreadEvents.length > 0) {
+      return unreadEvents.map((event) => event.content).join('\n\n')
+    }
     return this.getSlot(sessionId, 'insight')
   }
 
   /** 写入 insight */
   async putInsight(sessionId: string, content: string): Promise<void> {
-    await this.putSlot(sessionId, 'insight', content)
+    await this.appendInsightEvent(sessionId, content)
   }
 
   /** 清除 insight */
   async clearInsight(sessionId: string): Promise<void> {
+    const { rows } = await this.client.query(
+      `SELECT id FROM session_events
+       WHERE space_id = $1 AND stream = 'insight' AND session_id = $2
+       ORDER BY id DESC
+       LIMIT 1`,
+      [this.spaceId, sessionId],
+    )
+    const latestSequence = rows.length > 0 ? Number(rows[0]!['id']) : 0
+    await this.setInsightCursor(sessionId, latestSequence)
     await this.client.query(
       `DELETE FROM session_data WHERE session_id = $1 AND key = 'insight'`,
       [sessionId],
@@ -164,12 +178,95 @@ export class PgSessionStorage implements SessionStorage {
 
   /** 读取 memory（L2 / synthesis） */
   async getMemory(sessionId: string): Promise<string | null> {
+    const latestEvent = await this.getLatestMemoryEvent(sessionId)
+    if (latestEvent) {
+      return JSON.stringify(latestEvent)
+    }
     return this.getSlot(sessionId, 'memory')
   }
 
   /** 写入 memory */
   async putMemory(sessionId: string, content: string): Promise<void> {
     await this.putSlot(sessionId, 'memory', content)
+  }
+
+  /** 追加一条 memory 事件。 */
+  async appendMemoryEvent(sessionId: string, content: string, timestamp = new Date().toISOString()): Promise<EventEnvelope> {
+    const { rows } = await this.client.query(
+      `INSERT INTO session_events (space_id, stream, session_id, content, event_timestamp)
+       VALUES ($1, 'memory', $2, $3, $4)
+       RETURNING id, session_id AS "sessionId", content, event_timestamp AS "timestamp"`,
+      [this.spaceId, sessionId, content, timestamp],
+    )
+    return {
+      sessionId: rows[0]!['sessionId'] as string,
+      sequence: Number(rows[0]!['id']),
+      content: rows[0]!['content'] as string,
+      timestamp: (rows[0]!['timestamp'] as Date).toISOString(),
+    }
+  }
+
+  /** 读取某个 Session 最新的 memory 事件。 */
+  async getLatestMemoryEvent(sessionId: string): Promise<EventEnvelope | null> {
+    const { rows } = await this.client.query(
+      `SELECT id, session_id AS "sessionId", content, event_timestamp AS "timestamp"
+       FROM session_events
+       WHERE space_id = $1 AND stream = 'memory' AND session_id = $2
+       ORDER BY id DESC
+       LIMIT 1`,
+      [this.spaceId, sessionId],
+    )
+    if (rows.length === 0) return null
+    return {
+      sessionId: rows[0]!['sessionId'] as string,
+      sequence: Number(rows[0]!['id']),
+      content: rows[0]!['content'] as string,
+      timestamp: (rows[0]!['timestamp'] as Date).toISOString(),
+    }
+  }
+
+  /** 追加一条 insight 事件。 */
+  async appendInsightEvent(sessionId: string, content: string, timestamp = new Date().toISOString()): Promise<EventEnvelope> {
+    const { rows } = await this.client.query(
+      `INSERT INTO session_events (space_id, stream, session_id, content, event_timestamp)
+       VALUES ($1, 'insight', $2, $3, $4)
+       RETURNING id, session_id AS "sessionId", content, event_timestamp AS "timestamp"`,
+      [this.spaceId, sessionId, content, timestamp],
+    )
+    return {
+      sessionId: rows[0]!['sessionId'] as string,
+      sequence: Number(rows[0]!['id']),
+      content: rows[0]!['content'] as string,
+      timestamp: (rows[0]!['timestamp'] as Date).toISOString(),
+    }
+  }
+
+  /** 读取某个 Session 的 insight 事件。 */
+  async listInsightEvents(sessionId: string, afterSequence = 0): Promise<EventEnvelope[]> {
+    const { rows } = await this.client.query(
+      `SELECT id, session_id AS "sessionId", content, event_timestamp AS "timestamp"
+       FROM session_events
+       WHERE space_id = $1 AND stream = 'insight' AND session_id = $2 AND id > $3
+       ORDER BY id ASC`,
+      [this.spaceId, sessionId, afterSequence],
+    )
+    return rows.map((row) => ({
+      sessionId: row['sessionId'] as string,
+      sequence: Number(row['id']),
+      content: row['content'] as string,
+      timestamp: (row['timestamp'] as Date).toISOString(),
+    }))
+  }
+
+  /** 读取某个 Session 的 insight cursor。 */
+  async getInsightCursor(sessionId: string): Promise<number> {
+    const raw = await this.getSlot(sessionId, 'insight_cursor')
+    return raw ? Number(raw) : 0
+  }
+
+  /** 更新某个 Session 的 insight cursor。 */
+  async setInsightCursor(sessionId: string, sequence: number): Promise<void> {
+    await this.putSlot(sessionId, 'insight_cursor', String(sequence))
   }
 
   /** 在事务中执行操作 */

--- a/packages/session/src/__tests__/docs.test.ts
+++ b/packages/session/src/__tests__/docs.test.ts
@@ -43,11 +43,11 @@ describe('insight() + setInsight()', () => {
     expect(await session.insight()).toBe('Some insights here')
   })
 
-  it('setInsight 覆盖已有值', async () => {
+  it('setInsight 采用追加语义', async () => {
     const { session } = await makeSession()
     await session.setInsight('first')
     await session.setInsight('second')
-    expect(await session.insight()).toBe('second')
+    expect(await session.insight()).toBe('first\n\nsecond')
   })
 
   it('不同 session 的 insight 互不干扰', async () => {

--- a/packages/session/src/__tests__/event-envelope.test.ts
+++ b/packages/session/src/__tests__/event-envelope.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createSession } from '../create-session.js'
+import { createMainSession } from '../create-main-session.js'
+import { InMemoryStorageAdapter } from '../mocks/in-memory-storage.js'
+import type { ConsolidateFn, IntegrateFn } from '../types/functions.js'
+import { tryParseEnvelope } from '../context-utils.js'
+
+/** 快速创建测试用 Session 与共享 storage。 */
+async function makeSession() {
+  const storage = new InMemoryStorageAdapter()
+  const session = await createSession({ storage, label: 'Test' })
+  return { session, storage }
+}
+
+describe('EventEnvelope — consolidate 产出信封', () => {
+  it('consolidate 后 storage 中的 memory 是信封 JSON', async () => {
+    const { session, storage } = await makeSession()
+    await storage.appendRecord(session.meta.id, { role: 'user', content: 'Hello' })
+
+    await session.consolidate(async () => 'Summarized content')
+
+    const raw = await storage.getMemory(session.meta.id)
+    expect(raw).not.toBeNull()
+
+    const envelope = tryParseEnvelope(raw)
+    expect(envelope).not.toBeNull()
+    expect(envelope!.sessionId).toBe(session.meta.id)
+    expect(envelope!.sequence).toBe(1)
+    expect(envelope!.content).toBe('Summarized content')
+    expect(envelope!.timestamp).toBeTruthy()
+  })
+
+  it('多次 consolidate 时 sequence 单调递增', async () => {
+    const { session, storage } = await makeSession()
+
+    await session.consolidate(async () => 'first')
+    const raw1 = await storage.getMemory(session.meta.id)
+    const env1 = tryParseEnvelope(raw1)
+
+    await session.consolidate(async () => 'second')
+    const raw2 = await storage.getMemory(session.meta.id)
+    const env2 = tryParseEnvelope(raw2)
+
+    expect(env1!.sequence).toBe(1)
+    expect(env2!.sequence).toBe(2)
+    expect(env2!.content).toBe('second')
+  })
+
+  it('consolidate fn 接收信封内的 content，而不是原始 JSON', async () => {
+    const { session } = await makeSession()
+
+    await session.consolidate(async () => 'first summary')
+
+    const fn = vi.fn<ConsolidateFn>(async (currentMemory) => `updated: ${currentMemory}`)
+    await session.consolidate(fn)
+
+    expect(fn).toHaveBeenCalledWith('first summary', expect.any(Array))
+    expect(await session.memory()).toBe('updated: first summary')
+  })
+
+  it('memory() 返回解包后的 content', async () => {
+    const { session } = await makeSession()
+    await session.consolidate(async () => 'my memory')
+    expect(await session.memory()).toBe('my memory')
+  })
+})
+
+describe('EventEnvelope — getAllSessionL2s 解包', () => {
+  it('返回的 ChildL2Summary 包含 sequence 和 timestamp', async () => {
+    const storage = new InMemoryStorageAdapter()
+    await createMainSession({ storage })
+    const child = await createSession({ storage, label: '选校' })
+
+    await storage.appendRecord(child.meta.id, { role: 'user', content: 'test' })
+    await child.consolidate(async () => '已确定 top5 CS 项目')
+
+    const l2s = await storage.getAllSessionL2s()
+    expect(l2s).toHaveLength(1)
+    expect(l2s[0]!.l2).toBe('已确定 top5 CS 项目')
+    expect(l2s[0]!.sequence).toBe(1)
+    expect(l2s[0]!.timestamp).toBeTruthy()
+  })
+
+  it('向后兼容裸字符串 L2（无信封）', async () => {
+    const storage = new InMemoryStorageAdapter()
+    await createMainSession({ storage })
+    const child = await createSession({ storage, label: '文书' })
+
+    await storage.putMemory(child.meta.id, 'legacy L2 content')
+
+    const l2s = await storage.getAllSessionL2s()
+    expect(l2s).toHaveLength(1)
+    expect(l2s[0]!.l2).toBe('legacy L2 content')
+    expect(l2s[0]!.sequence).toBe(0)
+    expect(l2s[0]!.timestamp).toBe('')
+  })
+})
+
+describe('EventEnvelope — integration 链路', () => {
+  it('IntegrateFn 接收带 sequence 和 timestamp 的 ChildL2Summary', async () => {
+    const storage = new InMemoryStorageAdapter()
+    const main = await createMainSession({ storage })
+    const child = await createSession({ storage, label: '选校' })
+
+    await child.consolidate(async () => 'CS top5')
+
+    const fn = vi.fn<IntegrateFn>(async (children) => ({
+      synthesis: `共 ${children.length} 个子任务`,
+      insights: [],
+    }))
+    await main.integrate(fn)
+
+    const children = fn.mock.calls[0]![0]
+    expect(children[0]!.sequence).toBe(1)
+    expect(children[0]!.timestamp).toBeTruthy()
+    expect(children[0]!.l2).toBe('CS top5')
+  })
+
+  it('synthesis() 仍然返回普通字符串', async () => {
+    const storage = new InMemoryStorageAdapter()
+    const main = await createMainSession({ storage })
+    const child = await createSession({ storage, label: '选校' })
+    await child.consolidate(async () => 'CS top5')
+
+    await main.integrate(async () => ({
+      synthesis: '综合分析',
+      insights: [],
+    }))
+
+    expect(await main.synthesis()).toBe('综合分析')
+  })
+})

--- a/packages/session/src/__tests__/event-log-storage.test.ts
+++ b/packages/session/src/__tests__/event-log-storage.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { InMemoryStorageAdapter } from '../mocks/in-memory-storage.js'
+import { createSession, createMainSession } from '../index.js'
+
+describe('InMemoryStorageAdapter — memory event log', () => {
+  it('appendMemoryEvent 生成全局递增 sequence，并支持按 cursor 读取', async () => {
+    const storage = new InMemoryStorageAdapter()
+    const main = await createMainSession({ storage, label: 'Main' })
+    const child1 = await createSession({ storage, label: '美国选校' })
+    const child2 = await createSession({ storage, label: '英国选校' })
+
+    const event1 = await storage.appendMemoryEvent(child1.meta.id, '确认预算 50 万')
+    const event2 = await storage.appendMemoryEvent(child2.meta.id, '优先考虑就业导向项目')
+
+    expect(event1.sequence).toBe(1)
+    expect(event2.sequence).toBe(2)
+
+    await storage.setIntegrationCursor(main.meta.id, 1)
+    const unread = await storage.listMemoryEvents(await storage.getIntegrationCursor(main.meta.id))
+
+    expect(unread).toHaveLength(1)
+    expect(unread[0]!.sequence).toBe(2)
+    expect(unread[0]!.content).toBe('优先考虑就业导向项目')
+  })
+})
+
+describe('InMemoryStorageAdapter — append-only insights', () => {
+  it('多条 insight 追加后会一起暴露给下一次 send，再由 clearInsight 消费', async () => {
+    const storage = new InMemoryStorageAdapter()
+    const child = await createSession({ storage, label: '美国选校' })
+
+    await storage.appendInsightEvent(child.meta.id, '英国方向发现用户更看重就业')
+    await storage.appendInsightEvent(child.meta.id, '预算上限更新为 50 万')
+
+    expect(await storage.getInsight(child.meta.id)).toBe(
+      '英国方向发现用户更看重就业\n\n预算上限更新为 50 万',
+    )
+
+    await storage.clearInsight(child.meta.id)
+    expect(await storage.getInsight(child.meta.id)).toBeNull()
+
+    await storage.appendInsightEvent(child.meta.id, '新增：优先推荐 OPT 友好项目')
+    expect(await storage.getInsight(child.meta.id)).toBe('新增：优先推荐 OPT 友好项目')
+  })
+})

--- a/packages/session/src/__tests__/main-session.test.ts
+++ b/packages/session/src/__tests__/main-session.test.ts
@@ -106,8 +106,8 @@ describe('MainSession integrate()', () => {
     expect(children.find((c) => c.label === '选校')?.l2).toBe('已确定 top5 CS 项目')
   })
 
-  it('IntegrateFn 接收当前 synthesis', async () => {
-    const { main } = await makeWithChildren()
+  it('IntegrateFn 接收当前 synthesis 和新事件', async () => {
+    const { main, child1 } = await makeWithChildren()
 
     // 先做一次 integrate
     await main.integrate(async () => ({
@@ -115,15 +115,41 @@ describe('MainSession integrate()', () => {
       insights: [],
     }))
 
-    // 第二次应收到 first synthesis
-    const fn = vi.fn<IntegrateFn>(async (_children, current) => ({
+    await child1.consolidate(async () => '选校方向已更新为就业导向')
+
+    // 第二次应收到 first synthesis，并只看到新的 memory event
+    const fn = vi.fn<IntegrateFn>(async (_children, current, context) => ({
       synthesis: `updated from: ${current}`,
       insights: [],
     }))
     await main.integrate(fn)
 
     expect(fn.mock.calls[0]![1]).toBe('first synthesis')
+    expect(fn.mock.calls[0]![2]?.newEvents).toHaveLength(1)
+    expect(fn.mock.calls[0]![2]?.newEvents[0]?.content).toBe('选校方向已更新为就业导向')
     expect(await main.synthesis()).toBe('updated from: first synthesis')
+  })
+
+  it('没有新的 memory event 时跳过 IntegrateFn', async () => {
+    const { main } = await makeWithChildren()
+
+    await main.integrate(async () => ({
+      synthesis: 'first synthesis',
+      insights: [],
+    }))
+
+    const fn = vi.fn<IntegrateFn>(async () => ({
+      synthesis: 'should not run',
+      insights: [],
+    }))
+
+    const result = await main.integrate(fn)
+
+    expect(fn).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      synthesis: 'first synthesis',
+      insights: [],
+    })
   })
 
   it('insights 推送到子 Session', async () => {
@@ -274,6 +300,43 @@ describe('MainSession send()', () => {
 
     const persisted = await main.messages()
     expect(persisted.map((message) => message.role)).toEqual(['user', 'assistant', 'tool', 'assistant'])
+  })
+
+  it('toolResults continuation 回放时会解包 synthesis memory', async () => {
+    const llm = {
+      maxContextTokens: 1_000_000,
+      complete: vi
+        .fn()
+        .mockResolvedValueOnce({
+          content: '',
+          toolCalls: [{ id: 'tc_1', name: 'search', input: { q: 'test' } }],
+        })
+        .mockResolvedValueOnce({
+          content: '最终答案',
+          usage: { promptTokens: 10, completionTokens: 5 },
+        }),
+    } satisfies LLMAdapter
+    const { main } = await makeMainSession({ llm })
+    await main.integrate(async () => ({
+      synthesis: '这是综合认知',
+      insights: [],
+    }))
+
+    await main.send('搜索 test')
+    await main.send(JSON.stringify({
+      toolResults: [{
+        toolCallId: 'tc_1',
+        toolName: 'search',
+        args: { q: 'test' },
+        success: true,
+        data: { hits: 2 },
+        error: null,
+      }],
+    }))
+
+    const secondCall = (llm.complete as ReturnType<typeof vi.fn>).mock.calls[1]![0] as Array<Message>
+    expect(secondCall.find((message) => message.role === 'system' && message.content === '这是综合认知')).toBeTruthy()
+    expect(secondCall.some((message) => message.content.includes('"sessionId"'))).toBe(false)
   })
 
   it('自动存 L3（user + assistant）', async () => {

--- a/packages/session/src/__tests__/turn.test.ts
+++ b/packages/session/src/__tests__/turn.test.ts
@@ -70,6 +70,36 @@ describe('send() 契约', () => {
     expect(secondCall[3]!.content).toBe('问题2')
   })
 
+  it('多条 insight 会在下一次 send 时一起注入，然后一次性消费', async () => {
+    const capturedMessages: unknown[] = []
+    const llm = createMockLLM([simpleResponse, { content: '第二次回复' }])
+    const originalComplete = llm.complete.bind(llm)
+    llm.complete = async (msgs) => {
+      capturedMessages.push([...msgs])
+      return originalComplete(msgs)
+    }
+
+    const { session } = await makeSession({
+      llm,
+      systemPrompt: '你是助手',
+    })
+    await session.setInsight('英国方向发现用户更看重就业')
+    await session.setInsight('预算更新为 50 万')
+
+    await session.send('问题1')
+
+    const firstCall = capturedMessages[0] as Array<{ role: string; content: string }>
+    expect(firstCall[1]).toEqual({
+      role: 'system',
+      content: '英国方向发现用户更看重就业\n\n预算更新为 50 万',
+    })
+
+    await session.send('问题2')
+
+    const secondCall = capturedMessages[1] as Array<{ role: string; content: string }>
+    expect(secondCall.every((message) => message.content !== '英国方向发现用户更看重就业\n\n预算更新为 50 万')).toBe(true)
+  })
+
   it('send() 返回 toolCalls 时透传', async () => {
     const responseWithTools: LLMResult = {
       content: null,
@@ -145,6 +175,42 @@ describe('send() 契约', () => {
 
     const persisted = await session.messages()
     expect(persisted.map((message) => message.role)).toEqual(['user', 'assistant', 'tool', 'assistant'])
+  })
+
+  it('toolResults continuation 回放时会解包 event-envelope memory', async () => {
+    const capturedMessages: Message[][] = []
+    const llm = createMockLLM([
+      {
+        content: '',
+        toolCalls: [{ id: 'tc_1', name: 'search', input: { q: 'test' } }],
+      },
+      {
+        content: '最终答案',
+      },
+    ])
+    const originalComplete = llm.complete.bind(llm)
+    llm.complete = async (msgs, options) => {
+      capturedMessages.push(msgs.map((msg) => ({ ...msg })))
+      return originalComplete(msgs, options)
+    }
+
+    const { session } = await makeSession({ llm })
+    await session.consolidate(async () => '这是最新摘要')
+    await session.send('搜索 test')
+    await session.send(JSON.stringify({
+      toolResults: [{
+        toolCallId: 'tc_1',
+        toolName: 'search',
+        args: { q: 'test' },
+        success: true,
+        data: { hits: 3 },
+        error: null,
+      }],
+    }))
+
+    const secondCall = capturedMessages[1]!
+    expect(secondCall.find((message) => message.role === 'system' && message.content === '这是最新摘要')).toBeTruthy()
+    expect(secondCall.some((message) => message.content.includes('"sessionId"'))).toBe(false)
   })
 
   it('send() 会把 tools 定义传给 LLMAdapter.complete', async () => {

--- a/packages/session/src/context-utils.ts
+++ b/packages/session/src/context-utils.ts
@@ -1,5 +1,34 @@
 import type { Message } from './types/llm.js'
 import type { SessionStorage } from './types/storage.js'
+import type { EventEnvelope } from './types/functions.js'
+
+/** 尝试从 memory 槽位解析信封；非信封格式返回 null。 */
+export function tryParseEnvelope(raw: string | null): EventEnvelope | null {
+  if (!raw) return null
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>
+    if (typeof parsed['content'] !== 'string') return null
+    if (typeof parsed['sequence'] !== 'number') return null
+    if (typeof parsed['timestamp'] !== 'string') return null
+    if (typeof parsed['sessionId'] !== 'string') return null
+    return parsed as unknown as EventEnvelope
+  } catch {
+    return null
+  }
+}
+
+/** 从 memory 槽位提取事件内容；裸字符串原样返回。 */
+export function parseEnvelopeContent(raw: string | null): string | null {
+  if (!raw) return null
+  const envelope = tryParseEnvelope(raw)
+  return envelope ? envelope.content : raw
+}
+
+/** 从 memory 槽位提取事件序号；非信封格式返回 null。 */
+export function parseEnvelopeSequence(raw: string | null): number | null {
+  const envelope = tryParseEnvelope(raw)
+  return envelope ? envelope.sequence : null
+}
 
 /** 粗估消息的 token 数（字符数 / 4） */
 function estimateTokens(messages: Message[]): number {
@@ -92,7 +121,8 @@ export async function assembleSessionContext(
   }
 
   // 超阈值：检查是否有 L2 可用
-  const memory = await storage.getMemory(sessionId)
+  const rawMemory = await storage.getMemory(sessionId)
+  const memory = parseEnvelopeContent(rawMemory)
   if (!memory) {
     // 无 L2 → 仍发全量（无法压缩）
     return { messages: fullMessages, insightConsumed, userTimestamp, compressed: false }
@@ -134,7 +164,8 @@ export async function assembleMainSessionContext(
   }
 
   // 2. synthesis（始终注入）
-  const synthContent = await storage.getMemory(sessionId)
+  const rawSynthContent = await storage.getMemory(sessionId)
+  const synthContent = parseEnvelopeContent(rawSynthContent)
   if (synthContent) {
     prefixMessages.push({ role: 'system', content: synthContent })
   }

--- a/packages/session/src/create-main-session.ts
+++ b/packages/session/src/create-main-session.ts
@@ -8,7 +8,7 @@ import type {
   IntegrateFn, IntegrateResult, CreateMainSessionOptions, LoadMainSessionOptions,
   SendResult, StreamResult,
 } from './types/functions.js'
-import { assembleMainSessionContext } from './context-utils.js'
+import { assembleMainSessionContext, parseEnvelopeContent } from './context-utils.js'
 
 interface ToolResultEnvelope {
   toolResults: Array<{
@@ -64,7 +64,8 @@ async function assembleMainSessionReplayContext(
     messages.push({ role: 'system', content: sysPrompt })
   }
 
-  const synthContent = await storage.getMemory(sessionId)
+  const rawSynthContent = await storage.getMemory(sessionId)
+  const synthContent = parseEnvelopeContent(rawSynthContent)
   if (synthContent) {
     messages.push({ role: 'system', content: synthContent })
   }
@@ -294,7 +295,8 @@ function buildMainSession(
     },
 
     async synthesis(): Promise<string | null> {
-      return storage.getMemory(currentMeta.id)
+      const rawSynthesis = await storage.getMemory(currentMeta.id)
+      return parseEnvelopeContent(rawSynthesis)
     },
 
     async integrate(fn: IntegrateFn): Promise<IntegrateResult> {
@@ -307,19 +309,40 @@ function buildMainSession(
       const validChildSessionIds = new Set(childSummaries.map((child) => child.sessionId))
 
       // 2. 读取当前 synthesis
-      const currentSynthesis = await storage.getMemory(currentMeta.id)
+      const rawSynthesis = await storage.getMemory(currentMeta.id)
+      const currentSynthesis = parseEnvelopeContent(rawSynthesis)
 
-      // 3. 调用 IntegrateFn
-      const result = await fn(childSummaries, currentSynthesis)
+      // 3. 读取增量 memory 事件
+      const currentCursor = await storage.getIntegrationCursor(currentMeta.id)
+      const newEvents = await storage.listMemoryEvents(currentCursor)
+      const shouldBootstrap = currentCursor === 0
+
+      if (newEvents.length === 0 && !shouldBootstrap) {
+        return {
+          synthesis: currentSynthesis ?? '',
+          insights: [],
+        }
+      }
+
+      // 4. 调用 IntegrateFn
+      const result = await fn(childSummaries, currentSynthesis, { newEvents })
       const filteredInsights = result.insights.filter(({ sessionId }) => validChildSessionIds.has(sessionId))
 
-      // 4. 在事务中一起保存 synthesis 和有效 insights，避免部分写入。
+      // 5. 在事务中一起保存 synthesis 和有效 insights，避免部分写入。
       await storage.transaction(async (tx) => {
         await tx.putMemory(currentMeta.id, result.synthesis)
         for (const { sessionId, content } of filteredInsights) {
           await tx.putInsight(sessionId, content)
         }
       })
+
+      // 6. 推进 integration cursor。
+      if (newEvents.length > 0) {
+        const latestSequence = newEvents[newEvents.length - 1]!.sequence
+        await storage.setIntegrationCursor(currentMeta.id, latestSequence)
+      } else if (currentCursor === 0) {
+        await storage.setIntegrationCursor(currentMeta.id, -1)
+      }
 
       return { ...result, insights: filteredInsights }
     },

--- a/packages/session/src/create-session.ts
+++ b/packages/session/src/create-session.ts
@@ -3,8 +3,14 @@ import type { Session, MessageQueryOptions } from './types/session-api.js'
 import { SessionArchivedError } from './types/session-api.js'
 import type { SessionMeta, SessionMetaUpdate, ForkOptions } from './types/session.js'
 import type { Message } from './types/llm.js'
-import type { ConsolidateFn, CreateSessionOptions, LoadSessionOptions, SendResult, StreamResult } from './types/functions.js'
-import { assembleSessionContext } from './context-utils.js'
+import type {
+  ConsolidateFn,
+  CreateSessionOptions,
+  LoadSessionOptions,
+  SendResult,
+  StreamResult,
+} from './types/functions.js'
+import { assembleSessionContext, parseEnvelopeContent } from './context-utils.js'
 
 interface ToolResultEnvelope {
   toolResults: Array<{
@@ -68,8 +74,9 @@ async function assembleSessionReplayContext(
   }
 
   const memory = await storage.getMemory(sessionId)
-  if (memory) {
-    messages.push({ role: 'system', content: memory })
+  const memoryContent = parseEnvelopeContent(memory)
+  if (memoryContent) {
+    messages.push({ role: 'system', content: memoryContent })
   }
 
   const history = await storage.listRecords(sessionId)
@@ -324,17 +331,20 @@ function buildSession(
     },
 
     async memory(): Promise<string | null> {
-      return storage.getMemory(currentMeta.id)
+      const rawMemory = await storage.getMemory(currentMeta.id)
+      return parseEnvelopeContent(rawMemory)
     },
 
     async consolidate(fn: ConsolidateFn): Promise<void> {
       if (currentMeta.status === 'archived') {
         throw new SessionArchivedError(currentMeta.id)
       }
-      const currentMemory = await storage.getMemory(currentMeta.id)
+      const rawMemory = await storage.getMemory(currentMeta.id)
+      const currentMemory = parseEnvelopeContent(rawMemory)
       const messages = await storage.listRecords(currentMeta.id)
       const newMemory = await fn(currentMemory, messages)
-      await storage.putMemory(currentMeta.id, newMemory)
+      // 通过 append-only memory event 持久化新的 L2。
+      await storage.appendMemoryEvent(currentMeta.id, newMemory)
     },
 
     async trimRecords(keepRecent: number): Promise<void> {

--- a/packages/session/src/index.ts
+++ b/packages/session/src/index.ts
@@ -22,8 +22,10 @@ export type {
 export type {
   ConsolidateFn,
   IntegrateFn,
+  IntegrateContext,
   IntegrateResult,
   ChildL2Summary,
+  EventEnvelope,
   CreateSessionOptions,
   LoadSessionOptions,
   CreateMainSessionOptions,

--- a/packages/session/src/mocks/in-memory-storage.ts
+++ b/packages/session/src/mocks/in-memory-storage.ts
@@ -1,7 +1,8 @@
 import type { MainStorage, SessionStorage, ListRecordsOptions, TopologyNode } from '../types/storage.js'
 import type { SessionMeta, SessionFilter } from '../types/session.js'
-import type { ChildL2Summary } from '../types/functions.js'
+import type { ChildL2Summary, EventEnvelope } from '../types/functions.js'
 import type { Message } from '../types/llm.js'
+import { tryParseEnvelope } from '../context-utils.js'
 
 /**
  * InMemoryStorageAdapter — 完整的内存存储实现，主要用于测试
@@ -13,6 +14,12 @@ export class InMemoryStorageAdapter implements MainStorage {
   private memories = new Map<string, string>()
   private systemPrompts = new Map<string, string>()
   private insights = new Map<string, string>()
+  private memoryEvents: EventEnvelope[] = []
+  private insightEvents = new Map<string, EventEnvelope[]>()
+  private insightCursors = new Map<string, number>()
+  private integrationCursors = new Map<string, number>()
+  private nextMemorySequence = 1
+  private nextInsightSequences = new Map<string, number>()
   private nodes = new Map<string, TopologyNode>()
   private globals = new Map<string, unknown>()
 
@@ -84,18 +91,30 @@ export class InMemoryStorageAdapter implements MainStorage {
   }
 
   async getInsight(sessionId: string): Promise<string | null> {
+    const unreadEvents = await this.listInsightEvents(sessionId, await this.getInsightCursor(sessionId))
+    if (unreadEvents.length > 0) {
+      return unreadEvents.map((event) => event.content).join('\n\n')
+    }
     return this.insights.get(sessionId) ?? null
   }
 
   async putInsight(sessionId: string, content: string): Promise<void> {
-    this.insights.set(sessionId, content)
+    await this.appendInsightEvent(sessionId, content)
   }
 
   async clearInsight(sessionId: string): Promise<void> {
+    const latest = (this.insightEvents.get(sessionId) ?? []).at(-1)
+    if (latest) {
+      this.insightCursors.set(sessionId, latest.sequence)
+    }
     this.insights.delete(sessionId)
   }
 
   async getMemory(sessionId: string): Promise<string | null> {
+    const latestEvent = await this.getLatestMemoryEvent(sessionId)
+    if (latestEvent) {
+      return JSON.stringify(latestEvent)
+    }
     return this.memories.get(sessionId) ?? null
   }
 
@@ -103,16 +122,109 @@ export class InMemoryStorageAdapter implements MainStorage {
     this.memories.set(sessionId, content)
   }
 
+  /** 追加一条 memory 事件。 */
+  async appendMemoryEvent(sessionId: string, content: string, timestamp = new Date().toISOString()): Promise<EventEnvelope> {
+    const event: EventEnvelope = {
+      sessionId,
+      sequence: this.nextMemorySequence++,
+      timestamp,
+      content,
+    }
+    this.memoryEvents.push(event)
+    return { ...event }
+  }
+
+  /** 读取某个 Session 最新的 memory 事件。 */
+  async getLatestMemoryEvent(sessionId: string): Promise<EventEnvelope | null> {
+    for (let i = this.memoryEvents.length - 1; i >= 0; i--) {
+      const event = this.memoryEvents[i]
+      if (!event) continue
+      if (event.sessionId === sessionId) {
+        return { ...event }
+      }
+    }
+    return null
+  }
+
+  /** 追加一条 insight 事件。 */
+  async appendInsightEvent(sessionId: string, content: string, timestamp = new Date().toISOString()): Promise<EventEnvelope> {
+    const nextSequence = this.nextInsightSequences.get(sessionId) ?? 1
+    const event: EventEnvelope = {
+      sessionId,
+      sequence: nextSequence,
+      timestamp,
+      content,
+    }
+    const events = this.insightEvents.get(sessionId) ?? []
+    events.push(event)
+    this.insightEvents.set(sessionId, events)
+    this.nextInsightSequences.set(sessionId, nextSequence + 1)
+    return { ...event }
+  }
+
+  /** 读取某个 Session 的 insight 事件。 */
+  async listInsightEvents(sessionId: string, afterSequence = 0): Promise<EventEnvelope[]> {
+    return (this.insightEvents.get(sessionId) ?? [])
+      .filter((event) => event.sequence > afterSequence)
+      .map((event) => ({ ...event }))
+  }
+
+  /** 读取某个 Session 的 insight cursor。 */
+  async getInsightCursor(sessionId: string): Promise<number> {
+    return this.insightCursors.get(sessionId) ?? 0
+  }
+
+  /** 更新某个 Session 的 insight cursor。 */
+  async setInsightCursor(sessionId: string, sequence: number): Promise<void> {
+    this.insightCursors.set(sessionId, sequence)
+  }
+
   /** 扁平收集所有 standard session 的 L2 */
   async getAllSessionL2s(): Promise<ChildL2Summary[]> {
     const result: ChildL2Summary[] = []
     for (const session of this.sessions.values()) {
       if (session.role !== 'standard' || session.status !== 'active') continue
-      const l2 = this.memories.get(session.id)
-      if (l2 === undefined) continue
-      result.push({ sessionId: session.id, label: session.label, l2 })
+      const latestEvent = await this.getLatestMemoryEvent(session.id)
+      const rawMemory = latestEvent ? JSON.stringify(latestEvent) : this.memories.get(session.id)
+      if (rawMemory === undefined) continue
+      const envelope = tryParseEnvelope(rawMemory)
+      if (envelope) {
+        result.push({
+          sessionId: session.id,
+          label: session.label,
+          l2: envelope.content,
+          sequence: envelope.sequence,
+          timestamp: envelope.timestamp,
+        })
+        continue
+      }
+      result.push({
+        sessionId: session.id,
+        label: session.label,
+        l2: rawMemory,
+        sequence: 0,
+        timestamp: '',
+      })
     }
     return result
+  }
+
+  /** 读取指定序号之后的 memory 事件。 */
+  async listMemoryEvents(afterSequence = 0, limit?: number): Promise<EventEnvelope[]> {
+    const filtered = this.memoryEvents
+      .filter((event) => event.sequence > afterSequence)
+      .map((event) => ({ ...event }))
+    return limit === undefined ? filtered : filtered.slice(0, limit)
+  }
+
+  /** 读取 MainSession 的 integration cursor。 */
+  async getIntegrationCursor(sessionId: string): Promise<number> {
+    return this.integrationCursors.get(sessionId) ?? 0
+  }
+
+  /** 更新 MainSession 的 integration cursor。 */
+  async setIntegrationCursor(sessionId: string, sequence: number): Promise<void> {
+    this.integrationCursors.set(sessionId, sequence)
   }
 
   async putNode(node: TopologyNode): Promise<void> {

--- a/packages/session/src/types/functions.ts
+++ b/packages/session/src/types/functions.ts
@@ -4,11 +4,30 @@ import type { SessionStorage, MainStorage } from './storage.js'
 /** consolidate 函数签名：L3 → L2，接收当前 L2 和 L3 记录，返回新 L2 */
 export type ConsolidateFn = (currentMemory: string | null, messages: Message[]) => Promise<string>
 
+/**
+ * EventEnvelope — 事件信封
+ * 包裹 L2 / insight 内容的 metadata 层，框架只读信封字段，不解析 content
+ */
+export interface EventEnvelope {
+  /** 产出该事件的 Session ID */
+  sessionId: string
+  /** 单调递增序号，用于 cursor 追踪 */
+  sequence: number
+  /** 事件产生时间（ISO 8601） */
+  timestamp: string
+  /** 框架不解析的内容 */
+  content: string
+}
+
 /** 子 Session 的 L2 摘要，供 IntegrateFn 消费 */
 export interface ChildL2Summary {
   sessionId: string
   label: string
   l2: string
+  /** L2 产出时的序号 */
+  sequence: number
+  /** L2 产出时间 */
+  timestamp: string
 }
 
 /** IntegrateFn 的返回结果 */
@@ -19,10 +38,17 @@ export interface IntegrateResult {
   insights: Array<{ sessionId: string; content: string }>
 }
 
+/** integrate 调用时附带的增量上下文 */
+export interface IntegrateContext {
+  /** 自上次 integration cursor 以来新增的 memory 事件 */
+  newEvents: EventEnvelope[]
+}
+
 /** integrate 函数签名：所有子 L2 + 当前 synthesis → 新 synthesis + per-child insights */
 export type IntegrateFn = (
   children: ChildL2Summary[],
-  currentSynthesis: string | null
+  currentSynthesis: string | null,
+  context?: IntegrateContext,
 ) => Promise<IntegrateResult>
 
 /** createSession() 的选项 */

--- a/packages/session/src/types/storage.ts
+++ b/packages/session/src/types/storage.ts
@@ -1,6 +1,6 @@
 import type { SessionMeta, SessionFilter } from './session.js'
 import type { Message } from './llm.js'
-import type { ChildL2Summary } from './functions.js'
+import type { ChildL2Summary, EventEnvelope } from './functions.js'
 
 /** 列举消息记录时的选项 */
 export interface ListRecordsOptions {
@@ -44,6 +44,20 @@ export interface SessionStorage {
   /** 写入 Session 的记忆摘要 */
   putMemory(sessionId: string, content: string): Promise<void>
 
+  /** 追加一条 memory 事件（append-only L2 log） */
+  appendMemoryEvent(sessionId: string, content: string, timestamp?: string): Promise<EventEnvelope>
+  /** 读取某个 Session 最新的 memory 事件 */
+  getLatestMemoryEvent(sessionId: string): Promise<EventEnvelope | null>
+
+  /** 追加一条 insight 事件（append-only insight log） */
+  appendInsightEvent(sessionId: string, content: string, timestamp?: string): Promise<EventEnvelope>
+  /** 读取某个 Session 的所有未消费 insight 事件 */
+  listInsightEvents(sessionId: string, afterSequence?: number): Promise<EventEnvelope[]>
+  /** 读取某个 Session 的 insight 消费 cursor */
+  getInsightCursor(sessionId: string): Promise<number>
+  /** 更新某个 Session 的 insight 消费 cursor */
+  setInsightCursor(sessionId: string, sequence: number): Promise<void>
+
   /** 在事务中执行操作（内存实现可直接执行 fn） */
   transaction<T>(fn: (tx: SessionStorage) => Promise<T>): Promise<T>
 }
@@ -65,6 +79,13 @@ export interface TopologyNode {
 export interface MainStorage extends SessionStorage {
   /** 批量获取所有子 Session 的 L2（integration 专用，扁平收集，不走树） */
   getAllSessionL2s(): Promise<ChildL2Summary[]>
+
+  /** 读取指定序号之后的 memory 事件（integration 增量消费） */
+  listMemoryEvents(afterSequence?: number, limit?: number): Promise<EventEnvelope[]>
+  /** 读取 MainSession 的 integration cursor */
+  getIntegrationCursor(sessionId: string): Promise<number>
+  /** 更新 MainSession 的 integration cursor */
+  setIntegrationCursor(sessionId: string, sequence: number): Promise<void>
 
   /** 列举 Session，可按条件过滤 */
   listSessions(filter?: SessionFilter): Promise<SessionMeta[]>


### PR DESCRIPTION
## Why

Issue #35 里的前 5 个问题，本质上都指向同一个根因：当前跨 Session 通信缺少顺序、freshness、增量消费和可重放的基础设施。

这个 PR 不再沿用分步小补丁的方式，而是把这条统一方案一次性落地：
- 子 Session 的 L2 改为 append-only memory events
- MainSession 用 integration cursor 做增量消费
- insights 改为 append-only + cursor 消费
- session/server/core 三层一起补齐兼容接口与测试

## What changed

- 在 `@stello-ai/session` 中引入 `EventEnvelope`、增量 `IntegrateContext`、新的 storage event/cursor 接口
- `consolidate()` 改为写入 append-only memory events，`memory()` / `synthesis()` / 上下文组装统一自动解包 envelope
- `MainSession.integrate()` 改为基于 integration cursor 读取 `newEvents`，无新事件时直接跳过 `IntegrateFn`
- insight 从覆盖式槽位改为 append-only 事件流，消费后通过 cursor 前进
- 内存存储与 PostgreSQL 存储都补齐 memory/insight event log 实现
- 新增 `session_events` migration，并更新 PG 测试辅助与存储测试
- core 兼容类型同步更新，默认 integrate 测试补齐
- 修复 tool continuation replay 场景下 envelope memory/synthesis 直接泄露到上下文的问题

## What this PR solves

- 为跨 Session 通信补上 sequence / timestamp / append-only log 基础设施
- 避免 integration 每次只能依赖全量快照，支持 cursor-based 增量消费
- 避免 insight 替换策略导致的“记忆断崖”，改为追加后消费
- 为后续恢复、可观测性和更丰富的 event semantics 提供稳定底座

## What this PR does NOT solve

- fire-and-forget 失败后的完整 replay / retry 机制
- richer event semantics / query-back 机制
- 对 `ConsolidateFn / IntegrateFn` 配对关系的静态契约校验
- 生产级别的 event retention / compaction 策略

## Verification

- [x] `pnpm --filter @stello-ai/session test`
- [x] `pnpm --filter @stello-ai/core test`
- [x] `pnpm --filter @stello-ai/core typecheck`
- [x] `pnpm --filter @stello-ai/server typecheck`
- [x] `pnpm -r typecheck`
- [ ] `pnpm --filter @stello-ai/server test`（本地缺少 PostgreSQL，当前失败原因为 `ECONNREFUSED 127.0.0.1:5432`）

## Notes

- This PR supersedes the earlier step-wise PR #36.
- Refs #35