### PR TITLE
fix(core): 从 main session fork 不再继承 main 配置 (#55)

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @stello-ai/core
 
+## 0.5.2
+
+### Patch Changes
+
+- fix(core): 从 main session fork 不再继承 main 的配置（#55）
+  - Engine `forkSession` 在 `sourceSessionId === MAIN_SESSION_ID` 时跳过 `sessions.getConfig`，避免 main 的 `systemPrompt` / `skills` 通过四层合成链泄漏到子 session（违反 fork-design invariant #6）
+  - `SessionTreeImpl.createRoot` 使用固定 ID `MAIN_SESSION_ID = 'main'`，并在 main 已存在时幂等返回现有节点、不覆写数据
+  - 新增导出 `MAIN_SESSION_ID` 常量
+
+### ⚠️ Soft breaking — 自行实现 `SessionTree` 的宿主需同步
+
+内置 `SessionTreeImpl` 的宿主不受影响。若自行实现 `SessionTree`，`createRoot` 必须返回 `id === MAIN_SESSION_ID` 的 TopologyNode，否则 fork-from-main 的保护逻辑无法生效。
+
+已使用旧版本（UUID 作为 main session id）创建过 main session 的 installs 不会自动迁移：升级后下一次 `createMainSession` 调用会创建 id=`'main'` 的新根，旧 UUID 根将成为孤儿。宿主需要迁移请自行处理。
+
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stello-ai/core",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "The first open-source conversation topology engine",
   "license": "Apache-2.0",
   "author": "Stello Contributors",

--- a/packages/core/src/engine/__tests__/stello-engine.test.ts
+++ b/packages/core/src/engine/__tests__/stello-engine.test.ts
@@ -5,6 +5,7 @@ import type { ConfirmProtocol, SkillRouter } from '../../types/lifecycle';
 import { StelloEngineImpl } from '../stello-engine';
 import { TurnRunner, type ToolCallParser } from '../turn-runner';
 import { ForkProfileRegistryImpl } from '../fork-profile';
+import { MAIN_SESSION_ID } from '../../types/session';
 
 describe('StelloEngineImpl', () => {
   const jsonParser: ToolCallParser = {
@@ -899,6 +900,108 @@ describe('StelloEngineImpl', () => {
       });
 
       await expect(engine.forkSession({ label: 'UI' })).rejects.toThrow('Fork 不可用');
+    });
+  });
+
+  describe('forkSession from main session (issue #55)', () => {
+    it('从 main fork 时不读 getConfig，parent 层不参与合成链', async () => {
+      const getConfig = vi.fn().mockResolvedValue({ systemPrompt: 'main sys', skills: ['a'] });
+      const putConfig = vi.fn().mockResolvedValue(undefined);
+      const createChild = vi.fn().mockResolvedValue({
+        id: 'child-1', parentId: MAIN_SESSION_ID, children: [], refs: [],
+        depth: 1, index: 0, label: 'UI',
+      });
+      const sessionFork = vi.fn().mockResolvedValue({
+        id: 'child-1', meta: { id: 'child-1', turnCount: 0, status: 'active' },
+        turnCount: 0, send: vi.fn(), consolidate: vi.fn(),
+      });
+
+      const engine = new StelloEngineImpl({
+        session: {
+          id: MAIN_SESSION_ID,
+          meta: { id: MAIN_SESSION_ID, turnCount: 0, status: 'active' as const },
+          turnCount: 0, send: vi.fn(), consolidate: vi.fn(),
+          fork: sessionFork,
+        },
+        sessions: { ...sessions, createChild, getConfig, putConfig } as unknown as SessionTree,
+        memory, skills, confirm,
+        lifecycle: { bootstrap: vi.fn(), afterTurn: vi.fn() },
+        tools: { getToolDefinitions: vi.fn().mockReturnValue([]), executeTool: vi.fn() },
+      });
+
+      await engine.forkSession({ label: 'UI' });
+
+      expect(getConfig).not.toHaveBeenCalled();
+    });
+
+    it('从 main fork 时子 session 的 putConfig 不继承 main 的 systemPrompt/skills', async () => {
+      // 模拟宿主把 SerializableMainSessionConfig 存在同一 putConfig 槽位（issue #55 场景）
+      const getConfig = vi.fn().mockResolvedValue({ systemPrompt: 'main sys', skills: ['a'] });
+      const putConfig = vi.fn().mockResolvedValue(undefined);
+      const createChild = vi.fn().mockResolvedValue({
+        id: 'child-1', parentId: MAIN_SESSION_ID, children: [], refs: [],
+        depth: 1, index: 0, label: 'UI',
+      });
+      const sessionFork = vi.fn().mockResolvedValue({
+        id: 'child-1', meta: { id: 'child-1', turnCount: 0, status: 'active' },
+        turnCount: 0, send: vi.fn(), consolidate: vi.fn(),
+      });
+
+      const engine = new StelloEngineImpl({
+        session: {
+          id: MAIN_SESSION_ID,
+          meta: { id: MAIN_SESSION_ID, turnCount: 0, status: 'active' as const },
+          turnCount: 0, send: vi.fn(), consolidate: vi.fn(),
+          fork: sessionFork,
+        },
+        sessions: { ...sessions, createChild, getConfig, putConfig } as unknown as SessionTree,
+        memory, skills, confirm,
+        lifecycle: { bootstrap: vi.fn(), afterTurn: vi.fn() },
+        tools: { getToolDefinitions: vi.fn().mockReturnValue([]), executeTool: vi.fn() },
+      });
+
+      await engine.forkSession({ label: 'UI' });
+
+      // 子 session 的 putConfig 要么未被调用（合成结果为空），要么不含 main 的值
+      for (const [, cfg] of putConfig.mock.calls) {
+        expect(cfg.systemPrompt).toBeUndefined();
+        expect(cfg.skills).toBeUndefined();
+      }
+      // session.fork 传给子 session 的也不应包含 main 的 systemPrompt
+      expect(sessionFork).toHaveBeenCalledWith(expect.not.objectContaining({
+        systemPrompt: 'main sys',
+      }));
+    });
+
+    it('从非 main session fork 时仍然正常读取 parent config', async () => {
+      const getConfig = vi.fn().mockResolvedValue({ systemPrompt: 'parent sys' });
+      const createChild = vi.fn().mockResolvedValue({
+        id: 'child-1', parentId: 's1', children: [], refs: [],
+        depth: 2, index: 0, label: 'UI',
+      });
+      const sessionFork = vi.fn().mockResolvedValue({
+        id: 'child-1', meta: { id: 'child-1', turnCount: 0, status: 'active' },
+        turnCount: 0, send: vi.fn(), consolidate: vi.fn(),
+      });
+
+      const engine = new StelloEngineImpl({
+        session: {
+          id: 's1', meta: { id: 's1', turnCount: 0, status: 'active' as const },
+          turnCount: 0, send: vi.fn(), consolidate: vi.fn(),
+          fork: sessionFork,
+        },
+        sessions: { ...sessions, createChild, getConfig } as unknown as SessionTree,
+        memory, skills, confirm,
+        lifecycle: { bootstrap: vi.fn(), afterTurn: vi.fn() },
+        tools: { getToolDefinitions: vi.fn().mockReturnValue([]), executeTool: vi.fn() },
+      });
+
+      await engine.forkSession({ label: 'UI' });
+
+      expect(getConfig).toHaveBeenCalledWith('s1');
+      expect(sessionFork).toHaveBeenCalledWith(expect.objectContaining({
+        systemPrompt: 'parent sys',
+      }));
     });
   });
 });

--- a/packages/core/src/engine/stello-engine.ts
+++ b/packages/core/src/engine/stello-engine.ts
@@ -1,4 +1,5 @@
 import type { SessionTree } from '../types/session';
+import { MAIN_SESSION_ID } from '../types/session';
 import type { MemoryEngine, TurnRecord } from '../types/memory';
 import type {
   BootstrapResult,
@@ -320,8 +321,12 @@ export class StelloEngineImpl implements StelloEngine {
       throw new Error('Fork 不可用：当前 session runtime 未实现 fork()');
     }
 
-    // 读取父 regular session 的固化配置（可能为 null：历史 session 或 main session）
-    const parentFrozen = await this.sessions.getConfig(sourceSessionId);
+    // 从 main session fork 时不继承 main 的配置（invariant #6）：
+    // main 的 SerializableMainSessionConfig 与 regular 的 SerializableSessionConfig 共用
+    // 同一存储槽，需在读之前判断 source 角色、跳过读取。
+    const parentFrozen = sourceSessionId === MAIN_SESSION_ID
+      ? null
+      : await this.sessions.getConfig(sourceSessionId);
     const parent: SessionConfig = parentFrozen ?? {};
 
     // 合成最终配置：defaults → parent → profile → forkOptions

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 /** Stello SDK 版本号 */
-export const VERSION = '0.5.0';
+export const VERSION = '0.5.2';
 
 // 导出所有类型定义
 export type {
@@ -46,6 +46,9 @@ export type {
   SerializableSessionConfig,
   SerializableMainSessionConfig,
 } from './types';
+
+// 导出常量
+export { MAIN_SESSION_ID } from './types/session';
 
 // 导出实现
 export { NodeFileSystemAdapter } from './fs';

--- a/packages/core/src/session/__tests__/session-tree.test.ts
+++ b/packages/core/src/session/__tests__/session-tree.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { NodeFileSystemAdapter } from '../../fs/file-system-adapter';
 import { SessionTreeImpl } from '../session-tree';
+import { MAIN_SESSION_ID } from '../../types/session';
 
 describe('SessionTreeImpl', () => {
   let tmpDir: string;
@@ -41,6 +42,23 @@ describe('SessionTreeImpl', () => {
     expect(await fs.exists(`sessions/${root.id}/memory.md`)).toBe(true);
     expect(await fs.exists(`sessions/${root.id}/scope.md`)).toBe(true);
     expect(await fs.exists(`sessions/${root.id}/index.md`)).toBe(true);
+  });
+
+  it('createRoot 返回固定的 MAIN_SESSION_ID 作为 id', async () => {
+    const root = await tree.createRoot('Any');
+    expect(root.id).toBe(MAIN_SESSION_ID);
+  });
+
+  it('createRoot 幂等：第二次调用返回现有节点，不覆写 label 与已写入的内容', async () => {
+    const fs = new NodeFileSystemAdapter(tmpDir);
+    const first = await tree.createRoot('Original');
+    // 模拟用户在 memory.md 写入内容，确认后续 createRoot 不覆写
+    await fs.writeFile(`sessions/${first.id}/memory.md`, 'user content');
+
+    const second = await tree.createRoot('Ignored');
+    expect(second.id).toBe(first.id);
+    expect(second.label).toBe('Original');
+    expect(await fs.readFile(`sessions/${first.id}/memory.md`)).toBe('user content');
   });
 
   // ─── createChild ───

--- a/packages/core/src/session/session-tree.ts
+++ b/packages/core/src/session/session-tree.ts
@@ -7,6 +7,7 @@ import type {
   SessionTree,
   CreateSessionOptions,
 } from '../types/session';
+import { MAIN_SESSION_ID } from '../types/session';
 import type { SerializableSessionConfig } from '../types/session-config';
 
 /**
@@ -93,11 +94,19 @@ function toTopologyNode(stored: StoredMeta): TopologyNode {
 export class SessionTreeImpl implements SessionTree {
   constructor(private readonly fs: FileSystemAdapter) {}
 
-  /** 创建根 Session，初始化配套 .md 与 core.json */
+  /**
+   * 创建根 Session（main），初始化配套 .md 与 core.json
+   *
+   * 幂等：若 `MAIN_SESSION_ID` 对应的 meta 已存在，直接返回现有 TopologyNode，不覆写任何数据。
+   */
   async createRoot(label = 'Root'): Promise<TopologyNode> {
+    const existing = await this.fs.readJSON<StoredMeta>(metaPath(MAIN_SESSION_ID));
+    if (existing !== null) {
+      return toTopologyNode(existing);
+    }
     const ts = now();
     const stored: StoredMeta = {
-      id: randomUUID(),
+      id: MAIN_SESSION_ID,
       parentId: null,
       children: [],
       refs: [],
@@ -116,8 +125,8 @@ export class SessionTreeImpl implements SessionTree {
     await this.fs.writeFile(`sessions/${stored.id}/scope.md`, '');
     await this.fs.writeFile(`sessions/${stored.id}/index.md`, '');
     // 初始化 core.json（如果不存在）
-    const existing = await this.fs.readJSON('core.json');
-    if (existing === null) {
+    const coreExisting = await this.fs.readJSON('core.json');
+    if (coreExisting === null) {
       await this.fs.writeJSON('core.json', {});
     }
     return toTopologyNode(stored);

--- a/packages/core/src/types/session.ts
+++ b/packages/core/src/types/session.ts
@@ -2,6 +2,18 @@
 
 import type { SerializableSessionConfig } from './session-config';
 
+/**
+ * Main Session 的固定 ID。
+ *
+ * Stello 每个拓扑有且仅有一个 main session（root 节点），其 ID 必须为此值。
+ * Engine 通过比较 `sourceSessionId === MAIN_SESSION_ID` 判断 fork 来源是否为 main，
+ * 从而在合成链中跳过 parent 层（见 fork-design invariant #6）。
+ *
+ * 宿主若自行实现 `SessionTree`，`createRoot` 返回的 TopologyNode.id 必须等于此常量，
+ * 否则 fork-from-main 的行为会违反 spec。
+ */
+export const MAIN_SESSION_ID = 'main';
+
 /** Session 状态 */
 export type SessionStatus = 'active' | 'archived';
 


### PR DESCRIPTION
## Summary

修复 `Engine.forkSession` 无条件读取 `sessions.getConfig` 导致 main session 的 `systemPrompt` / `skills` 通过四层合成链泄漏到子 session，违反 `fork-design` invariant #6（"从 main session fork 不继承 main 的配置 — main 不参与 regular session 的合成链"）。

根因：`SerializableMainSessionConfig` 与 `SerializableSessionConfig` 结构相容，宿主（如 KitKit）将两者持久化到同一存储列——engine 层完全无法通过 `getConfig(rootId)` 的返回值区分这是 main 还是 regular 的固化配置。

## 实现

- 新增 `MAIN_SESSION_ID = 'main'` 常量，`SessionTreeImpl.createRoot` 使用固定 ID
- `createRoot` 变为幂等：若 main 已存在则返回现有 `TopologyNode`，不覆写任何数据（避免重复初始化时清空已有 `memory.md` 等内容）
- `forkSession` 在 `sourceSessionId === MAIN_SESSION_ID` 时跳过 `getConfig` 读取，parent 层保持为空对象
- 导出 `MAIN_SESSION_ID`，自行实现 `SessionTree` 的宿主需同步该常量

## Soft breaking

内置 `SessionTreeImpl` 的宿主不受影响。自行实现 `SessionTree` 的宿主需要把 `createRoot` 返回的 `TopologyNode.id` 改为 `MAIN_SESSION_ID`，否则修复逻辑无法触发。

旧版本（UUID 作为 main id）创建过 main session 的 installs 不会自动迁移：升级后下一次 `createMainSession` 会创建 id=`'main'` 的新根，旧 UUID 根成为孤儿。宿主需要迁移请自行处理。

## Test plan

- [x] `session-tree.test.ts` 新增：`createRoot` 返回 `MAIN_SESSION_ID` / 幂等返回现有节点不覆写 `memory.md`
- [x] `stello-engine.test.ts` 新增：
  - 从 main fork 时 `getConfig` 未被调用
  - Issue #55 tripwire — main 有 `putConfig({systemPrompt, skills})` 时，子 session 的 `putConfig` 与 `session.fork` 均不含 main 的值
  - 从非 main session fork 时仍读取 parent config（baseline 未回归）
- [x] `pnpm test` — 251/251 全绿
- [x] `pnpm typecheck` — 清洁

## Version

`@stello-ai/core` bump 到 `0.5.2`（patch — 内部 fix + 导出新常量；SessionTree 的自实现者需同步作为 soft breaking 在 CHANGELOG 中告知）

Closes #55